### PR TITLE
HDR tone mapping for flatbuffers

### DIFF
--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -299,6 +299,8 @@
   "edt_conf_fbs_heading_title": "Flatbuffers Server",
   "edt_conf_fbs_timeout_expl": "If no data are received for the given period, the component will be (soft) disabled.",
   "edt_conf_fbs_timeout_title": "Timeout",
+  "edt_conf_fbs_tonemapping_expl": "If enabled, HyperHDR will try to correct colors of the HDR10 content that was received by flatbuffers as SDR format. Default 3D LUT file <span class='fw-bold'>'lut_lin_tables.3d'</span> is already included.<span class='fw-bold'> You can generate one and preview the effect using link in the 'Advanced menu'.</span><br/>Your typical hidden configuration folder to upload that file in is (check 'Logs' page to confirm):<br/> Rpi→&#47;home&#47;pi&#47;.hyperhdr<br/>Windows→c:&#47;Users&#47;NAME&#47;.hyperhdr",
+  "edt_conf_fbs_tonemapping_title": "HDR to SDR tone mapping",
   "edt_conf_fg_display_expl": "Select which desktop should be captured (multi monitor setup)",
   "edt_conf_fg_display_title": "Display",
   "edt_conf_fg_frequency_Hz_expl": "How fast new pictures are captured",

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -299,8 +299,6 @@
   "edt_conf_fbs_heading_title": "Flatbuffers Server",
   "edt_conf_fbs_timeout_expl": "If no data are received for the given period, the component will be (soft) disabled.",
   "edt_conf_fbs_timeout_title": "Timeout",
-  "edt_conf_fbs_tonemapping_expl": "If enabled, HyperHDR will try to correct colors of the HDR10 content that was received by flatbuffers as SDR format. Default 3D LUT file <span class='fw-bold'>'lut_lin_tables.3d'</span> is already included.<span class='fw-bold'> You can generate one and preview the effect using link in the 'Advanced menu'.</span><br/>Your typical hidden configuration folder to upload that file in is (check 'Logs' page to confirm):<br/> Rpi→&#47;home&#47;pi&#47;.hyperhdr<br/>Windows→c:&#47;Users&#47;NAME&#47;.hyperhdr",
-  "edt_conf_fbs_tonemapping_title": "HDR to SDR tone mapping",
   "edt_conf_fg_display_expl": "Select which desktop should be captured (multi monitor setup)",
   "edt_conf_fg_display_title": "Display",
   "edt_conf_fg_frequency_Hz_expl": "How fast new pictures are captured",
@@ -1146,5 +1144,7 @@
   "perf_no" : "No",
   "perf_decoding_time": "time",
   "perf_frames" : "frames",
-  "perf_invalid_frames" : "invalid frames"
+  "perf_invalid_frames" : "invalid frames",
+  "edt_conf_fbs_tonemapping_expl": "If enabled, HyperHDR will try to correct colors of the HDR10 content that was received by flatbuffers as SDR format. Default 3D LUT file <span class='fw-bold'>'lut_lin_tables.3d'</span> is already included.<span class='fw-bold'> You can generate one and preview the effect using link in the 'Advanced menu'.</span><br/>Your typical hidden configuration folder to upload that file in is (check 'Logs' page to confirm):<br/> Rpi→&#47;home&#47;pi&#47;.hyperhdr<br/>Windows→c:&#47;Users&#47;NAME&#47;.hyperhdr",
+  "edt_conf_fbs_tonemapping_title": "HDR to SDR tone mapping"
 } 

--- a/include/flatbufserver/FlatBufferConnection.h
+++ b/include/flatbufserver/FlatBufferConnection.h
@@ -75,6 +75,8 @@ public:
 	///
 	void sendMessage(const uint8_t* buffer, uint32_t size);
 
+	bool isFree();
+
 public slots:
 	///
 	/// @brief Set the leds according to the given image
@@ -99,6 +101,8 @@ signals:
 	/// @brief emits when a new videoMode was requested from flatbuf client
 	///
 	///void setVideoModeHdr(int hdr);
+
+	void onImage(const Image<ColorRgb>& image);
 
 private:
 
@@ -132,4 +136,5 @@ private:
 	flatbuffers::FlatBufferBuilder _builder;
 
 	bool _registered;
+	bool _free;
 };

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -3,6 +3,7 @@
 // util
 #include <utils/Logger.h>
 #include <utils/settings.h>
+#include <utils/PixelFormat.h>
 
 // qt
 #include <QVector>
@@ -15,13 +16,13 @@ class NetOrigin;
 
 ///
 /// @brief A TcpServer to receive images of different formats with Google Flatbuffer
-/// Images will be forwarded to all HyperHdr instances
+/// Images will be forwarded to all HyperHdr instanceshttp://localhost:8090
 ///
 class FlatBufferServer : public QObject
 {
 	Q_OBJECT
 public:
-	FlatBufferServer(const QJsonDocument& config, QObject* parent = nullptr);
+	FlatBufferServer(const QJsonDocument& config, const QString& configurationPath, QObject* parent = nullptr);
 	~FlatBufferServer() override;
 
 public slots:
@@ -56,6 +57,11 @@ private:
 	///
 	void stopServer();
 
+	///
+	/// @brief Load LUT file
+	///
+	void loadLutFile();
+
 
 private:
 	QTcpServer* _server;
@@ -67,4 +73,10 @@ private:
 	BonjourServiceRegister* _serviceRegister = nullptr;
 
 	QVector<FlatBufferClient*> _openConnections;
+
+	// tone mapping
+	uint8_t _hdrToneMappingEnabled;
+	uint8_t* _lutBuffer;
+	bool _lutBufferInit;
+	QString	_configurationPath;
 };

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -23,7 +23,10 @@ class FlatBufferServer : public QObject
 	Q_OBJECT
 public:
 	FlatBufferServer(const QJsonDocument& config, const QString& configurationPath, QObject* parent = nullptr);
-	~FlatBufferServer() override;	
+	~FlatBufferServer() override;
+
+	static FlatBufferServer* instance;
+	static FlatBufferServer* getInstance(){ return instance; }
 
 signals:
 	void hdrToneMappingChanged(bool enabled, uint8_t* lutBuffer);

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -25,7 +25,7 @@ public:
 	~FlatBufferServer() override;
 
 	static FlatBufferServer* instance;
-	static FlatBufferServer* getInstance(){ return instance; }
+	static FlatBufferServer* getInstance() { return instance; }
 
 signals:
 	void hdrToneMappingChanged(bool enabled, uint8_t* lutBuffer);

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -23,7 +23,10 @@ class FlatBufferServer : public QObject
 	Q_OBJECT
 public:
 	FlatBufferServer(const QJsonDocument& config, const QString& configurationPath, QObject* parent = nullptr);
-	~FlatBufferServer() override;
+	~FlatBufferServer() override;	
+
+signals:
+	void hdrToneMappingChanged(bool enabled, uint8_t* lutBuffer);
 
 public slots:
 	///
@@ -34,6 +37,8 @@ public slots:
 	void handleSettingsUpdate(settings::type type, const QJsonDocument& config);
 
 	void initServer();
+
+	void setHdrToneMappingEnabled(bool enabled);
 
 private slots:
 	///
@@ -75,7 +80,7 @@ private:
 	QVector<FlatBufferClient*> _openConnections;
 
 	// tone mapping
-	uint8_t _hdrToneMappingEnabled;
+	bool _hdrToneMappingEnabled;
 	uint8_t* _lutBuffer;
 	bool _lutBufferInit;
 	QString	_configurationPath;

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -65,6 +65,12 @@ private:
 	///
 	void stopServer();
 
+
+	///
+	/// @brief Get shared LUT file folder
+	///
+	QString GetSharedLut();
+
 	///
 	/// @brief Load LUT file
 	///

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -3,7 +3,6 @@
 // util
 #include <utils/Logger.h>
 #include <utils/settings.h>
-#include <utils/PixelFormat.h>
 
 // qt
 #include <QVector>
@@ -16,7 +15,7 @@ class NetOrigin;
 
 ///
 /// @brief A TcpServer to receive images of different formats with Google Flatbuffer
-/// Images will be forwarded to all HyperHdr instanceshttp://localhost:8090
+/// Images will be forwarded to all HyperHdr instances
 ///
 class FlatBufferServer : public QObject
 {

--- a/sources/api/API.cpp
+++ b/sources/api/API.cpp
@@ -25,6 +25,7 @@
 #include <HyperhdrConfig.h>
 #include <utils/SysInfo.h>
 #include <utils/ColorSys.h>
+#include <flatbufserver/FlatBufferServer.h>
 
 // bonjour wrapper
 #include <bonjour/bonjourbrowserwrapper.h>
@@ -211,7 +212,7 @@ bool API::setComponentState(const QString& comp, bool& compState, QString& reply
 		input = "VIDEOGRABBER";
 	Components component = stringToComponent(input);
 	if (component == COMP_ALL)
-	{		
+	{
 		QMetaObject::invokeMethod(HyperHdrIManager::getInstance(), "toggleStateAllInstances", Qt::QueuedConnection, Q_ARG(bool, compState));
 
 		return true;
@@ -237,7 +238,11 @@ void API::setLedMappingType(int type, hyperhdr::Components callerComp)
 
 void API::setVideoModeHdr(int hdr, hyperhdr::Components callerComp)
 {
-	QMetaObject::invokeMethod(GrabberWrapper::getInstance(), "setHdrToneMappingEnabled", Qt::QueuedConnection, Q_ARG(int, hdr));
+	if (GrabberWrapper::getInstance() != nullptr)
+		QMetaObject::invokeMethod(GrabberWrapper::getInstance(), "setHdrToneMappingEnabled", Qt::QueuedConnection, Q_ARG(int, hdr));
+
+	if (FlatBufferServer::getInstance() != nullptr)
+		QMetaObject::invokeMethod(FlatBufferServer::getInstance(), "setHdrToneMappingEnabled", Qt::QueuedConnection, Q_ARG(bool, hdr));
 }
 
 bool API::setEffect(const EffectCmdData& dat, hyperhdr::Components callerComp)

--- a/sources/flatbufserver/FlatBufferClient.cpp
+++ b/sources/flatbufserver/FlatBufferClient.cpp
@@ -74,7 +74,6 @@ void FlatBufferClient::setHdrToneMappingEnabled(bool enabled, uint8_t* lutBuffer
 {
 	_hdrToneMappingEnabled = enabled;
 	_lutBuffer = lutBuffer;
-	Debug(_log, "_hdrToneMappingEnabled = %i", _hdrToneMappingEnabled);
 }
 
 void FlatBufferClient::disconnected()

--- a/sources/flatbufserver/FlatBufferClient.cpp
+++ b/sources/flatbufserver/FlatBufferClient.cpp
@@ -9,7 +9,7 @@
 // util includes
 #include <utils/ImageResampler.h>
 
-FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, uint8_t hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent)
+FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, bool hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent)
 	: QObject(parent)
 	, _log(Logger::getInstance("FLATBUFSERVER"))
 	, _socket(socket)
@@ -68,6 +68,13 @@ void FlatBufferClient::readyRead()
 void FlatBufferClient::forceClose()
 {
 	_socket->close();
+}
+
+void FlatBufferClient::setHdrToneMappingEnabled(bool enabled, uint8_t* lutBuffer)
+{
+	_hdrToneMappingEnabled = enabled;
+	_lutBuffer = lutBuffer;
+	Debug(_log, "_hdrToneMappingEnabled = %i", _hdrToneMappingEnabled);
 }
 
 void FlatBufferClient::disconnected()

--- a/sources/flatbufserver/FlatBufferClient.cpp
+++ b/sources/flatbufserver/FlatBufferClient.cpp
@@ -6,7 +6,10 @@
 #include <QTimer>
 #include <QRgb>
 
-FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, QObject* parent)
+// util includes
+#include <utils/ImageResampler.h>
+
+FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, uint8_t hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent)
 	: QObject(parent)
 	, _log(Logger::getInstance("FLATBUFSERVER"))
 	, _socket(socket)
@@ -14,8 +17,8 @@ FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, QObject* par
 	, _timeoutTimer(new QTimer(this))
 	, _timeout(timeout * 1000)
 	, _priority()
-	, _hdrToneMappingEnabled(0)
-	, _lutBuffer(nullptr)
+	, _hdrToneMappingEnabled(hdrToneMappingEnabled)
+	, _lutBuffer(lutBuffer)
 {
 	// timer setup
 	_timeoutTimer->setSingleShot(true);

--- a/sources/flatbufserver/FlatBufferClient.cpp
+++ b/sources/flatbufserver/FlatBufferClient.cpp
@@ -14,6 +14,8 @@ FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, QObject* par
 	, _timeoutTimer(new QTimer(this))
 	, _timeout(timeout * 1000)
 	, _priority()
+	, _hdrToneMappingEnabled(0)
+	, _lutBuffer(nullptr)
 {
 	// timer setup
 	_timeoutTimer->setSingleShot(true);
@@ -164,6 +166,10 @@ void FlatBufferClient::handleImageCommand(const hyperhdrnet::Image* image)
 
 		Image<ColorRgb> imageDest(width, height);
 		memmove(imageDest.memptr(), imageData->data(), imageData->size());
+
+		// tone mapping
+		ImageResampler::applyLUT((uint8_t*)imageDest.memptr(), imageDest.width(), imageDest.height(), _lutBuffer, _hdrToneMappingEnabled);
+
 		emit setGlobalInputImage(_priority, imageDest, duration);
 	}
 

--- a/sources/flatbufserver/FlatBufferClient.cpp
+++ b/sources/flatbufserver/FlatBufferClient.cpp
@@ -7,7 +7,7 @@
 #include <QRgb>
 
 // util includes
-#include <utils/ImageResampler.h>
+#include <utils/FrameDecoder.h>
 
 FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, bool hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent)
 	: QObject(parent)
@@ -177,7 +177,7 @@ void FlatBufferClient::handleImageCommand(const hyperhdrnet::Image* image)
 		memmove(imageDest.memptr(), imageData->data(), imageData->size());
 
 		// tone mapping
-		ImageResampler::applyLUT((uint8_t*)imageDest.memptr(), imageDest.width(), imageDest.height(), _lutBuffer, _hdrToneMappingEnabled);
+		FrameDecoder::applyLUT((uint8_t*)imageDest.memptr(), imageDest.width(), imageDest.height(), _lutBuffer, _hdrToneMappingEnabled);
 
 		emit setGlobalInputImage(_priority, imageDest, duration);
 	}

--- a/sources/flatbufserver/FlatBufferClient.cpp
+++ b/sources/flatbufserver/FlatBufferClient.cpp
@@ -9,7 +9,7 @@
 // util includes
 #include <utils/FrameDecoder.h>
 
-FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, bool hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent)
+FlatBufferClient::FlatBufferClient(QTcpSocket* socket, int timeout, bool hdrToneMappingEnabled, uint8_t* lutBuffer, QObject* parent)
 	: QObject(parent)
 	, _log(Logger::getInstance("FLATBUFSERVER"))
 	, _socket(socket)

--- a/sources/flatbufserver/FlatBufferClient.h
+++ b/sources/flatbufserver/FlatBufferClient.h
@@ -26,7 +26,7 @@ public:
 	/// @param timeout  The timeout when a client is automatically disconnected and the priority unregistered
 	/// @param parent   The parent
 	///
-	explicit FlatBufferClient(QTcpSocket* socket, int timeout, bool hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent = nullptr);
+	explicit FlatBufferClient(QTcpSocket* socket, int timeout, bool hdrToneMappingEnabled, uint8_t* lutBuffer, QObject* parent = nullptr);
 
 signals:
 	///

--- a/sources/flatbufserver/FlatBufferClient.h
+++ b/sources/flatbufserver/FlatBufferClient.h
@@ -26,7 +26,7 @@ public:
 	/// @param timeout  The timeout when a client is automatically disconnected and the priority unregistered
 	/// @param parent   The parent
 	///
-	explicit FlatBufferClient(QTcpSocket* socket, int timeout, uint8_t hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent = nullptr);
+	explicit FlatBufferClient(QTcpSocket* socket, int timeout, bool hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent = nullptr);
 
 signals:
 	///
@@ -64,6 +64,11 @@ public slots:
 	/// @brief close the socket and call disconnected()
 	///
 	void forceClose();
+
+	///
+	/// @brief Change HDR tone mapping
+	///
+	void setHdrToneMappingEnabled(bool enabled, uint8_t* lutBuffer);
 
 private slots:
 	///
@@ -142,6 +147,6 @@ private:
 	flatbuffers::FlatBufferBuilder _builder;
 
 	// tone mapping
-	uint8_t	_hdrToneMappingEnabled;
+	bool _hdrToneMappingEnabled;
 	uint8_t* _lutBuffer;
 };

--- a/sources/flatbufserver/FlatBufferClient.h
+++ b/sources/flatbufserver/FlatBufferClient.h
@@ -140,4 +140,8 @@ private:
 
 	// Flatbuffers builder
 	flatbuffers::FlatBufferBuilder _builder;
+
+	// tone mapping
+	uint8_t	_hdrToneMappingEnabled;
+	uint8_t* _lutBuffer;
 };

--- a/sources/flatbufserver/FlatBufferClient.h
+++ b/sources/flatbufserver/FlatBufferClient.h
@@ -26,7 +26,7 @@ public:
 	/// @param timeout  The timeout when a client is automatically disconnected and the priority unregistered
 	/// @param parent   The parent
 	///
-	explicit FlatBufferClient(QTcpSocket* socket, int timeout, QObject* parent = nullptr);
+	explicit FlatBufferClient(QTcpSocket* socket, int timeout, uint8_t hdrToneMappingEnabled, uint8_t* lutBuffer, QObject *parent = nullptr);
 
 signals:
 	///

--- a/sources/flatbufserver/FlatBufferServer.cpp
+++ b/sources/flatbufserver/FlatBufferServer.cpp
@@ -5,8 +5,6 @@
 // util
 #include <utils/NetOrigin.h>
 #include <utils/GlobalSignals.h>
-#include <utils/ImageResampler.h>
-#include <utils/ColorSys.h>
 
 // bonjour
 #ifdef ENABLE_AVAHI

--- a/sources/flatbufserver/FlatBufferServer.cpp
+++ b/sources/flatbufserver/FlatBufferServer.cpp
@@ -169,14 +169,30 @@ void FlatBufferServer::stopServer()
 	}
 }
 
+QString FlatBufferServer::GetSharedLut()
+{
+#ifdef __APPLE__
+	QString ret = QString("%1%2").arg(QCoreApplication::applicationDirPath()).arg("/../lut");
+	QFileInfo info(ret);
+	ret = info.absoluteFilePath();
+	return ret;
+#else
+	return QCoreApplication::applicationDirPath();
+#endif
+}
+
 // copied from Grabber::loadLutFile()
 // color should always be RGB24 for flatbuffers
 void FlatBufferServer::loadLutFile()
 {
 	QString fileName1 = QString("%1%2").arg(_configurationPath).arg("/lut_lin_tables.3d");
-	QString fileName2 = QString("%1%2").arg(QCoreApplication::applicationDirPath()).arg("/lut_lin_tables.3d");
+	QString fileName2 = QString("%1%2").arg(GetSharedLut()).arg("/lut_lin_tables.3d");
+	QList<QString> files({fileName1, fileName2});
+
+#ifdef __linux__
 	QString fileName3 = QString("/usr/share/hyperhdr/lut/lut_lin_tables.3d");
-	QList<QString> files({fileName1, fileName2, fileName3});
+	files.append(fileName3);
+#endif
 
 	_lutBufferInit = false;
 

--- a/sources/flatbufserver/FlatBufferServer.cpp
+++ b/sources/flatbufserver/FlatBufferServer.cpp
@@ -67,10 +67,6 @@ void FlatBufferServer::setHdrToneMappingEnabled(bool enabled)
 
 	// inform clients
 	emit hdrToneMappingChanged(_hdrToneMappingEnabled && _lutBufferInit, _lutBuffer);
-
-	// // make emit
-	// emit HdrChanged(mode);
-	// emit HyperHdrIManager::getInstance()->setNewComponentStateToAllInstances(hyperhdr::Components::COMP_HDR, (mode != 0));
 }
 
 void FlatBufferServer::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
@@ -90,7 +86,6 @@ void FlatBufferServer::handleSettingsUpdate(settings::type type, const QJsonDocu
 		
 		// HDR tone mapping
 		setHdrToneMappingEnabled(obj["hdrToneMapping"].toBool());
-		Debug(_log, "_hdrToneMappingEnabled = %i", _hdrToneMappingEnabled);
 
 		// new timeout just for new connections
 		_timeout = obj["timeout"].toInt(5000);

--- a/sources/flatbufserver/FlatBufferServer.cpp
+++ b/sources/flatbufserver/FlatBufferServer.cpp
@@ -22,6 +22,8 @@
 
 #define LUT_FILE_SIZE 50331648
 
+FlatBufferServer* FlatBufferServer::instance = nullptr;
+
 FlatBufferServer::FlatBufferServer(const QJsonDocument& config, const QString& configurationPath, QObject* parent)
 	: QObject(parent)
 	, _server(new QTcpServer(this))
@@ -33,7 +35,7 @@ FlatBufferServer::FlatBufferServer(const QJsonDocument& config, const QString& c
 	, _lutBufferInit(false)
 	, _configurationPath(configurationPath)
 {
-
+	FlatBufferServer::instance = this;
 }
 
 FlatBufferServer::~FlatBufferServer()
@@ -87,7 +89,7 @@ void FlatBufferServer::handleSettingsUpdate(settings::type type, const QJsonDocu
 		}
 		
 		// HDR tone mapping
-		setHdrToneMappingEnabled(obj["hdrToneMapping"].toBool(false)? 1: 0);
+		setHdrToneMappingEnabled(obj["hdrToneMapping"].toBool());
 		Debug(_log, "_hdrToneMappingEnabled = %i", _hdrToneMappingEnabled);
 
 		// new timeout just for new connections

--- a/sources/hyperhdr/hyperhdr.cpp
+++ b/sources/hyperhdr/hyperhdr.cpp
@@ -277,7 +277,7 @@ void HyperHdrDaemon::startNetworkServices()
 	connect(this, &HyperHdrDaemon::settingsChanged, _jsonServer, &JsonServer::handleSettingsUpdate);
 
 	// Create FlatBuffer server in thread
-	_flatBufferServer = new FlatBufferServer(getSetting(settings::type::FLATBUFSERVER));
+	_flatBufferServer = new FlatBufferServer(getSetting(settings::type::FLATBUFSERVER), _rootPath);
 	QThread* fbThread = new QThread(this);
 	fbThread->setObjectName("FlatBufferServerThread");
 	_flatBufferServer->moveToThread(fbThread);

--- a/sources/hyperhdrbase/MessageForwarder.cpp
+++ b/sources/hyperhdrbase/MessageForwarder.cpp
@@ -242,7 +242,8 @@ void MessageForwarder::forwardFlatbufferMessage(const QString& name, const Image
 	if (_forwarder_enabled)
 	{
 		for (int i = 0; i < _forwardClients.size(); i++)
-			_forwardClients.at(i)->setImage(image);
+			if (_forwardClients.at(i)->isFree())
+				emit _forwardClients.at(i)->onImage(image);
 	}
 }
 

--- a/sources/hyperhdrbase/MessageForwarder.cpp
+++ b/sources/hyperhdrbase/MessageForwarder.cpp
@@ -84,6 +84,20 @@ void MessageForwarder::handleSettingsUpdate(settings::type type, const QJsonDocu
 		if (!_flatSlaves.isEmpty() && obj["enable"].toBool() && _forwarder_enabled)
 		{
 			InfoIf(obj["enable"].toBool(true), _log, "Forward now to flatbuffer targets '%s'", QSTRING_CSTR(_flatSlaves.join(", ")));
+
+			hyperhdr::Components activeCompId = _hyperhdr->getPriorityInfo(_hyperhdr->getCurrentPriority()).componentId;
+
+			disconnect(_hyperhdr, &HyperHdrInstance::forwardV4lProtoMessage, 0, 0);
+			disconnect(_hyperhdr, &HyperHdrInstance::forwardSystemProtoMessage, 0, 0);
+
+			if (activeCompId == hyperhdr::COMP_SYSTEMGRABBER)
+			{
+				connect(_hyperhdr, &HyperHdrInstance::forwardSystemProtoMessage, this, &MessageForwarder::forwardFlatbufferMessage, Qt::UniqueConnection);
+			}
+			else  if (activeCompId == hyperhdr::COMP_VIDEOGRABBER)
+			{				
+				connect(_hyperhdr, &HyperHdrInstance::forwardV4lProtoMessage, this, &MessageForwarder::forwardFlatbufferMessage, Qt::UniqueConnection);
+			}
 		}
 		else if (_flatSlaves.isEmpty() || !obj["enable"].toBool() || !_forwarder_enabled)
 		{

--- a/sources/hyperhdrbase/schema/schema-flatbufServer.json
+++ b/sources/hyperhdrbase/schema/schema-flatbufServer.json
@@ -32,6 +32,15 @@
 			"minimum" : 1,
 			"default" : 5,
 			"propertyOrder" : 3
+		},
+		"hdrToneMapping" :
+		{
+			"type" : "boolean",
+			"format": "checkbox",
+			"required" : true,
+			"title" : "edt_conf_fbs_tonemapping_title",
+			"default" : false,
+			"propertyOrder" : 4
 		}
 	},
 	"additionalProperties" : false


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
Introduces HDR tone mapping for flatbuffers input.

In some cases (depending on TV modell / capturing library in use) [PicCap](https://github.com/TBSniller/piccap) (Hyperion Sender App on LG TVs) is sending dim/pale images when HDR/Dolby Vision content is playing. Tone mapping helps to get this image data back to "normal".

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:
Before:
![before](https://user-images.githubusercontent.com/22025013/154788854-cdadeb9a-0d4c-4b30-8e3f-9f9af59d38e1.png)
After:
![after](https://user-images.githubusercontent.com/22025013/154788859-97d7c35e-2914-400c-95cf-1fa529ba74e5.png)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated
- [x] No, couldn't find CHANGELOG.md

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
