### PR TITLE
CMake: build-time test - backwards compatibility with older glibc

### DIFF
--- a/sources/leddevice/CMakeLists.txt
+++ b/sources/leddevice/CMakeLists.txt
@@ -86,6 +86,7 @@ target_link_libraries(leddevice
 )
 
 if(NOT WIN32)
+	include(CheckCSourceCompiles)
 	# Glibc compatibilty check
 	check_c_source_compiles("
 		#include <time.h>

--- a/sources/leddevice/CMakeLists.txt
+++ b/sources/leddevice/CMakeLists.txt
@@ -85,6 +85,21 @@ target_link_libraries(leddevice
 	ssdp
 )
 
+if(NOT WIN32)
+	# Glibc compatibilty check
+	check_c_source_compiles("
+		#include <time.h>
+		#include <sys/time.h>
+		int main() {
+		struct timespec t;
+		return clock_gettime(CLOCK_REALTIME, &t);
+		}
+		" GLIBC_HAS_CLOCK_GETTIME)
+	IF(NOT GLIBC_HAS_CLOCK_GETTIME)
+		target_link_libraries(leddevice rt)
+	endif()
+endif()
+
 IF ( HAVE_SERIAL_LED )
 	target_link_libraries(leddevice Qt${Qt_VERSION}::SerialPort)
 endif()


### PR DESCRIPTION
* Checks whether glibc has former librt function 'clock_gettime' included (that's since glibc 2.17).
* glibc <2.17 requires linking with 'librt' explicitly.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [X] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
