### PR TITLE
Flatbuffers: selectable custom LUT files

### DIFF
--- a/assets/webconfig/content/json_api.html
+++ b/assets/webconfig/content/json_api.html
@@ -369,10 +369,14 @@
 									<input class="form-check-input" type="radio" name="hdrModeState" id="hdr_on_mode" value="1">
 									<label class="form-check-label" for="hdr_on_mode" data-i18n="general_btn_on"></label>
 								</div>
-								<div class="form-check">
-									<input class="form-check-input" type="radio" name="hdrModeState" id="hdr_border_mode" value="2">
-									<label class="form-check-label" for="hdr_border_mode" data-i18n="general_mode_border"></label>
-								</div>
+							</div>
+						</div>
+						<div class="row mt-1">
+							<div class="col-8 text-start">
+								<div class="input-group">
+									<span class="input-group-text mb-1" data-i18n="json_api_flatbuffers_user_lut"></span>									
+									<input class="form-control mb-1" type="text" id="flatbuffersUserLut">									
+								</div>				
 							</div>
 						</div>
 					</div>

--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -1120,8 +1120,7 @@
   "json_api_effect_color_expl" : "Set desired color or effect for the active instance.",
   "json_api_clear" : "Clear a priority",
   "json_api_clear_expl" : "Clear priority from effects and preset colors.",
-  "json_api_hdr" : "HDR mode",
-  "json_api_hdr_expl" : "Turn on/off HDR tone mapping for USB grabber. 'Border mode' works only for MJPEG stream.",
+  "json_api_hdr" : "HDR mode",  
   "json_api_components_expl_multi":"You can run multiple commands with just one link. Maximum lenght is 2048 chars. They all will be executed but you will receive only one response (check out logs for all the output). Just put your links' <code>request</code> content into the format (note first '?' char and next '&' chars):<br><code>http://IP:PORT/json-rpc?request=request1&request=request2&request=request3...</code>",
   "edt_conf_stream_autoResume_title" : "Auto resume",
   "edt_conf_stream_autoResume_expl" : "Try restarting video capture if the video stream stops. Use with caution as it is not a cure for hardware problems of the grabber.",
@@ -1176,5 +1175,7 @@
   "edt_conf_mqtt_is_ssl_title" : "SSL",
   "edt_conf_mqtt_is_ssl_expl" : "Use SSL protocol",
   "edt_conf_mqtt_ssl_ignore_errors_title" : "Ignore SSL errors",
-  "edt_conf_mqtt_ssl_ignore_errors_expl" : "Ignore all SSL errors such as self-signed certificates etc. Use with caution."
+  "edt_conf_mqtt_ssl_ignore_errors_expl" : "Ignore all SSL errors such as self-signed certificates etc. Use with caution.",
+  "json_api_flatbuffers_user_lut" : "Flatbuffers LUT filename",
+  "json_api_hdr_expl" : "Turn on/off HDR tone mapping. You can also pass the name of the user LUT file in the user HyperHDR home folder to be used for Flatbuffers tone mapping."
 } 

--- a/assets/webconfig/js/json_api.js
+++ b/assets/webconfig/js/json_api.js
@@ -515,17 +515,17 @@ function BuildClearJson()
 var componentHdr = 
 `{
 	"command":"videomodehdr",
-	"HDR":{0}
+	"HDR":{0},
+	"flatbuffers_user_lut_filename":"{1}"
 }`;
  
-$('input[name="hdrModeState"]').change(
+$('input[name="hdrModeState"], #flatbuffersUserLut').change(
 	function(){
 		if ($("input[name='hdrModeState']:checked").val())
 		{
 			BuildHdrJson();
 		}
 	});
-
 	
 function BuildHdrJson()
 {
@@ -533,8 +533,10 @@ function BuildHdrJson()
 		$(this).removeClass('disabled');
 	});
 		
-	var state = $('input[name="hdrModeState"]:checked').val();
-	var finJson = componentHdr.replace("{0}", state);
+	var state = $('input[name="hdrModeState"]:checked').val();	
+	var flatbufferUserLut = $('#flatbuffersUserLut').val();
+	var finJson = componentHdr.replace("{0}", state).replace("{1}", flatbufferUserLut);
+	
 	$("#hdrMode_json").html(finJson);
 }
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/api/API.h
+++ b/include/api/API.h
@@ -125,6 +125,12 @@ protected:
 	void setVideoModeHdr(int hdr, hyperhdr::Components callerComp = hyperhdr::COMP_INVALID);
 
 	///
+	/// @brief Set user LUT filename for flatbuffers tone mapping
+	/// @param userLUTfile	user LUT filename
+	///
+	void setFlatbufferUserLUT(QString userLUTfile);
+
+	///
 	/// @brief Set an effect
 	/// @param dat        The effect data
 	/// @param callerComp The HYPERHDR COMPONENT that calls this function! e.g. PROT/FLATBUF

--- a/include/flatbufserver/FlatBufferServer.h
+++ b/include/flatbufserver/FlatBufferServer.h
@@ -44,6 +44,8 @@ public slots:
 
 	void initServer();
 
+	void setUserLut(QString filename);
+
 	void setHdrToneMappingEnabled(int mode);
 
 	int getHdrToneMappingEnabled();
@@ -105,4 +107,5 @@ private:
 	uint8_t*	_lutBuffer;
 	bool		_lutBufferInit;
 	QString		_configurationPath;
+	QString		_userLutFile;
 };

--- a/sources/api/API.cpp
+++ b/sources/api/API.cpp
@@ -245,6 +245,12 @@ void API::setVideoModeHdr(int hdr, hyperhdr::Components callerComp)
 		QMetaObject::invokeMethod(FlatBufferServer::getInstance(), "setHdrToneMappingEnabled", Qt::QueuedConnection, Q_ARG(int, hdr));
 }
 
+void API::setFlatbufferUserLUT(QString userLUTfile)
+{
+	if (FlatBufferServer::getInstance() != nullptr)
+		QMetaObject::invokeMethod(FlatBufferServer::getInstance(), "setUserLut", Qt::QueuedConnection, Q_ARG(QString, userLUTfile));
+}
+
 bool API::setEffect(const EffectCmdData& dat, hyperhdr::Components callerComp)
 {
 	int res;

--- a/sources/api/JSONRPC_schema/schema-videomodehdr.json
+++ b/sources/api/JSONRPC_schema/schema-videomodehdr.json
@@ -15,6 +15,10 @@
 			"minimum" : 0,
 			"maximum" : 2,
 			"required": true
+		},
+		"flatbuffers_user_lut_filename": {
+			"type" : "string",			
+			"required": false
 		}
 	},
 	"additionalProperties": false

--- a/sources/api/JsonAPI.cpp
+++ b/sources/api/JsonAPI.cpp
@@ -1288,6 +1288,11 @@ void JsonAPI::handleProcessingCommand(const QJsonObject& message, const QString&
 
 void JsonAPI::handleVideoModeHdrCommand(const QJsonObject& message, const QString& command, int tan)
 {
+	if (message.contains("flatbuffers_user_lut_filename"))
+	{
+		API::setFlatbufferUserLUT(message["flatbuffers_user_lut_filename"].toString(""));
+	}
+
 	API::setVideoModeHdr(message["HDR"].toInt());
 	sendSuccessReply(command, tan);
 }

--- a/sources/flatbufserver/FlatBufferServer.cpp
+++ b/sources/flatbufserver/FlatBufferServer.cpp
@@ -35,6 +35,7 @@ FlatBufferServer::FlatBufferServer(const QJsonDocument& config, const QString& c
 	, _lutBuffer(nullptr)
 	, _lutBufferInit(false)
 	, _configurationPath(configurationPath)
+	, _userLutFile("")
 {
 	FlatBufferServer::instance = this;
 }
@@ -240,6 +241,13 @@ void FlatBufferServer::loadLutFile()
 	files.append(fileName3);
 #endif
 
+	if (!_userLutFile.isEmpty())
+	{
+		QString userFile = QString("%1/%2").arg(_configurationPath).arg(_userLutFile);
+		files.prepend(userFile);
+		Debug(_log, "Adding user LUT file for searching: %s", QSTRING_CSTR(userFile));
+	}
+
 	_lutBufferInit = false;
 
 	if (_hdrToneMappingMode)
@@ -294,4 +302,11 @@ void FlatBufferServer::importFromProtoHandler(int priority, int duration, const 
 	FrameDecoder::applyLUT((uint8_t*)image.memptr(), image.width(), image.height(), _lutBuffer, _hdrToneMappingMode);
 
 	emit GlobalSignals::getInstance()->setGlobalImage(priority, image, duration);
+}
+
+void FlatBufferServer::setUserLut(QString filename)
+{
+	_userLutFile = filename.replace("~", "").replace("/","").replace("..", "");
+
+	Info(_log, "Setting user LUT filename to: '%s'", QSTRING_CSTR(_userLutFile));
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

The JSON API for controlling tone mapping has been extended to include an optional LUT file name for FlatBuffers.
This allows to select proper LUT for tone mapping depending on the external video properties.
For example you can have two or more LUT files for selection: one for SDR, one for HDR, one for DV etc.
HyperHDR expects that these files are located in HyperHDR home folder e.g. /home/pi/.hyperhdr



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

![obraz](https://user-images.githubusercontent.com/69086569/188498086-82ff9712-58ee-47aa-a18a-6a49b7449d18.png)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No