### PR TITLE
Add ZasLuke Capture card support for MJPEG tone mapping

### DIFF
--- a/sources/grabber/MF/MFWorker.cpp
+++ b/sources/grabber/MF/MFWorker.cpp
@@ -273,7 +273,7 @@ void MFWorker::process_image_jpg_mt()
 		return;
 	}
 	
-	if (_subsamp != TJSAMP_422 && _hdrToneMappingEnabled > 0)
+	if ((_subsamp != TJSAMP_422 && _subsamp != TJSAMP_420) && _hdrToneMappingEnabled > 0)
 	{
 		emit newFrameError(_workerIndex, QString("%1: %2").arg(UNSUPPORTED_DECODER).arg(_subsamp), _currentFrame);
 		return;
@@ -301,7 +301,7 @@ void MFWorker::process_image_jpg_mt()
 			}		
 
 		FrameDecoder::processImage(_cropLeft, _cropRight, _cropTop, _cropBottom,
-			jpegBuffer, _width, _height, _width, PixelFormat::MJPEG, _lutBuffer, image);
+			jpegBuffer, _width, _height, _width, (_subsamp == TJSAMP_422) ? PixelFormat::MJPEG : PixelFormat::I420, _lutBuffer, image);
 
 		free(jpegBuffer);
 	}

--- a/sources/grabber/v4l2/V4L2Worker.cpp
+++ b/sources/grabber/v4l2/V4L2Worker.cpp
@@ -255,7 +255,7 @@ void V4L2Worker::process_image_jpg_mt()
 		return;
 	}
 
-	if (_subsamp != TJSAMP_422 && _hdrToneMappingEnabled > 0)
+	if ((_subsamp != TJSAMP_422 && _subsamp != TJSAMP_420) && _hdrToneMappingEnabled > 0)
 	{
 		emit newFrameError(_workerIndex, QString("%1: %2").arg(UNSUPPORTED_DECODER).arg(_subsamp), _currentFrame);
 		return;
@@ -283,7 +283,7 @@ void V4L2Worker::process_image_jpg_mt()
 		}
 
 		FrameDecoder::processImage(_cropLeft, _cropRight, _cropTop, _cropBottom,
-			jpegBuffer, _width, _height, _width, PixelFormat::MJPEG, _lutBuffer, image);
+			jpegBuffer, _width, _height, _width, (_subsamp == TJSAMP_422) ? PixelFormat::MJPEG : PixelFormat::I420, _lutBuffer, image);
 
 		free(jpegBuffer);
 	}


### PR DESCRIPTION
ZasLuke grabber is using non-standard low quality codec TJSAMP_420 for MJPEG and tone mapping since v18 supported only popular TJSAMP_422 mode. But the encoding of TJSAMP_420 appears to be identical to already supported I420. This PR brings back tone mapping for MJPEG stream for ZasLuke grabber.

Reported here: https://github.com/awawa-dev/HyperHDR/discussions/323

