### PR TITLE
Github Action: upgrade runner to macos-12

### DIFF
--- a/.ci/ci_build.sh
+++ b/.ci/ci_build.sh
@@ -46,17 +46,18 @@ if [[ "$CI_NAME" == 'osx' || "$CI_NAME" == 'darwin' ]]; then
 		mkdir build || exit 1
 		cd build
 		ccache -p
-		cmake ${cachecommand} -DPLATFORM=${PLATFORM} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ../ || exit 2
-		make -j $(sysctl -n hw.ncpu) package || exit 3
-
+		cmake ${cachecommand} -DPLATFORM=${PLATFORM} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ../ || exit 2
+		make -j $(sysctl -n hw.ncpu) || exit 3
+		sudo cpack || exit 3
 		exit 0;
 		exit 1 || { echo "---> HyperHDR compilation failed! Abort"; exit 5; }
 	else
 		echo "Not using ccache"
 		mkdir build || exit 1
 		cd build
-		cmake -DPLATFORM=${PLATFORM} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ../ || exit 2
-		make -j $(sysctl -n hw.ncpu) package || exit 3
+		cmake -DPLATFORM=${PLATFORM} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ../ || exit 2
+		make -j $(sysctl -n hw.ncpu) || exit 3
+		sudo cpack || exit 3
 		exit 0;
 		exit 1 || { echo "---> HyperHDR compilation failed! Abort"; exit 5; }
 	fi

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -94,7 +94,9 @@ jobs:
 
   macOS:
     name: macOS
-    runs-on: macOS-10.15 
+    runs-on: macos-12
+    env:     
+      QT_VERSION: "5"
     steps:
       # Checkout
       - uses: actions/checkout@v1
@@ -122,8 +124,16 @@ jobs:
       # Install deps
       - name: Install deps
         shell: bash
-        run: brew update && brew install qt@6 xz ccache
-
+        run: brew update && brew install qt@${{ env.QT_VERSION }} xz ccache
+        
+      # Set env
+      - name: Set QT5 env
+        if: ( env.QT_VERSION == '5' )
+        shell: bash
+        run: |
+            export Qt5_DIR=`brew --prefix qt5`;
+            echo "Qt5_DIR=$Qt5_DIR" >> $GITHUB_ENV
+            
         # Build process
       - name: Build packages
         env:

--- a/sources/flatbufserver/FlatBufferConnection.cpp
+++ b/sources/flatbufserver/FlatBufferConnection.cpp
@@ -153,18 +153,16 @@ void FlatBufferConnection::setRegister(const QString& origin, int priority)
 		uint8_t((size) & 0xFF) };
 
 	// write message
-	int count = 0;
-
 	if (_socket != nullptr)
 	{
-		count += _socket->write(reinterpret_cast<const char*>(header), 4);
-		count += _socket->write(reinterpret_cast<const char*>(_builder.GetBufferPointer()), size);
+		_socket->write(reinterpret_cast<const char*>(header), 4);
+		_socket->write(reinterpret_cast<const char*>(_builder.GetBufferPointer()), size);
 		_socket->flush();
 	}
 	else if (_domain != nullptr)
 	{
-		count += _domain->write(reinterpret_cast<const char*>(header), 4);
-		count += _domain->write(reinterpret_cast<const char*>(_builder.GetBufferPointer()), size);
+		_domain->write(reinterpret_cast<const char*>(header), 4);
+		_domain->write(reinterpret_cast<const char*>(_builder.GetBufferPointer()), size);
 		_domain->flush();
 	}
 	_builder.Clear();
@@ -295,17 +293,16 @@ void FlatBufferConnection::sendMessage(const uint8_t* buffer, uint32_t size)
 		uint8_t((size) & 0xFF) };
 
 	// write message
-	int count = 0;
 	if (_socket != nullptr)
 	{
-		count += _socket->write(reinterpret_cast<const char*>(header), 4);
-		count += _socket->write(reinterpret_cast<const char*>(buffer), size);
+		_socket->write(reinterpret_cast<const char*>(header), 4);
+		_socket->write(reinterpret_cast<const char*>(buffer), size);
 		_socket->flush();
 	}
 	else if (_domain != nullptr)
 	{
-		count += _domain->write(reinterpret_cast<const char*>(header), 4);
-		count += _domain->write(reinterpret_cast<const char*>(buffer), size);
+		_domain->write(reinterpret_cast<const char*>(header), 4);
+		_domain->write(reinterpret_cast<const char*>(buffer), size);
 		_domain->flush();
 	}
 }

--- a/sources/hyperhdr/CMakeLists.txt
+++ b/sources/hyperhdr/CMakeLists.txt
@@ -8,6 +8,7 @@ if (WIN32)
 	set(hyperhdr_POWER_MNG "WinSuspend.cpp;WinSuspend.h")
 elseif (APPLE)
 	set(hyperhdr_POWER_MNG "MacSuspend.mm;MacSuspend.h")
+	find_library(APPKIT_FRAMEWORK AppKit REQUIRED)
 elseif (Qt${Qt_VERSION}DBus_FOUND)
 	set(hyperhdr_POWER_MNG "LinuxSuspend.cpp;LinuxSuspend.h")
 	set(hyperhdr_POWER_MNG_DBUS "Qt${Qt_VERSION}::DBus")
@@ -44,6 +45,7 @@ target_link_libraries(hyperhdr
 	resources
 	Qt${Qt_VERSION}::Widgets
 	${hyperhdr_POWER_MNG_DBUS}
+	${APPKIT_FRAMEWORK}
 )
 
 if (USE_STATIC_QT_PLUGINS)


### PR DESCRIPTION
Updated Github Action runner to macos-12 as 10.15 will be deprecated soon.

![obraz](https://user-images.githubusercontent.com/69086569/189097804-1c841ec0-2a50-4547-8208-09412d8cb329.png)

To maintain backward binary compatibility with macOS 10.15, QT must be downgraded to 5.15, because of brew repository is targeting QT6@macos-12 using newer system framework.