### PR TITLE
Improved HyperHDR web server startup

### DIFF
--- a/assets/webconfig/js/ui_utils.js
+++ b/assets/webconfig/js/ui_utils.js
@@ -72,7 +72,11 @@ function loadContent(event, forceRefresh)
 		if ((typeof lastSelectedInstance !== 'undefined') && 
 			(typeof window.serverInfo.instance[lastSelectedInstance] !== 'undefined') &&
 			 typeof(window.serverInfo.instance[lastSelectedInstance].running) !== 'undefined' && window.serverInfo.instance[lastSelectedInstance].running)
+		{
+			$("#page-content").off();
 			instanceSwitch(lastSelectedInstance);
+			return;
+		}
 		else
 			removeStorage('lastSelectedInstance', false);
 

--- a/include/base/HyperHdrIManager.h
+++ b/include/base/HyperHdrIManager.h
@@ -37,6 +37,7 @@ public:
 	static HyperHdrIManager* getInstance() { return HIMinstance; }
 	static HyperHdrIManager* HIMinstance;
 	QString getRootPath() { return _rootPath; }
+	bool areInstancesReady();
 
 public slots:
 	bool isCEC();
@@ -193,11 +194,12 @@ private:
 private:
 	Logger* _log;
 	InstanceTable* _instanceTable;
-	const QString _rootPath;
+	const QString	_rootPath;
 	QMap<quint8, HyperHdrInstance*> _runningInstances;
-	QList<quint8> _startQueue;
+	QList<quint8>	_startQueue;
 
-	bool _readonlyMode;
+	bool	_readonlyMode;
+	int		_fireStarter;
 
 	/// All pending requests
 	QMap<quint8, PendingRequests> _pendingRequests;

--- a/sources/base/HyperHdrIManager.cpp
+++ b/sources/base/HyperHdrIManager.cpp
@@ -15,6 +15,7 @@ HyperHdrIManager::HyperHdrIManager(const QString& rootPath, QObject* parent, boo
 	, _instanceTable(new InstanceTable(rootPath, this, readonlyMode))
 	, _rootPath(rootPath)
 	, _readonlyMode(readonlyMode)
+	, _fireStarter(0)
 {
 	HIMinstance = this;
 	qRegisterMetaType<InstanceState>("InstanceState");
@@ -59,9 +60,21 @@ QVector<QVariantMap> HyperHdrIManager::getInstanceData() const
 	return instances;
 }
 
+bool HyperHdrIManager::areInstancesReady()
+{
+	if (_fireStarter > 0)
+		_fireStarter--;
+
+	return (_fireStarter < 1);
+}
+
 void HyperHdrIManager::startAll()
 {
-	for (const auto& entry : _instanceTable->getAllInstances(true))
+	auto instanceList = _instanceTable->getAllInstances(true);
+
+	_fireStarter = instanceList.count();
+
+	for (const auto& entry : instanceList)
 	{
 		startInstance(entry["instance"].toInt());
 	}

--- a/sources/hyperhdr/hyperhdr.cpp
+++ b/sources/hyperhdr/hyperhdr.cpp
@@ -189,10 +189,13 @@ void HyperHdrDaemon::instanceStateChanged(InstanceState state, quint8 instance, 
 	// start web server if needed
 	if (state == InstanceState::H_STARTED)
 	{
-		if (_webserver != nullptr && !_webserver->thread()->isRunning())
-			_webserver->thread()->start();
-		if (_sslWebserver != nullptr && !_sslWebserver->thread()->isRunning())
-			_sslWebserver->thread()->start();
+		if (_instanceManager->areInstancesReady())
+		{
+			if (_webserver != nullptr && !_webserver->thread()->isRunning())
+				_webserver->thread()->start();
+			if (_sslWebserver != nullptr && !_sslWebserver->thread()->isRunning())
+				_sslWebserver->thread()->start();
+		}
 	}
 
 	// cec

--- a/sources/hyperhdr/hyperhdr.cpp
+++ b/sources/hyperhdr/hyperhdr.cpp
@@ -186,6 +186,15 @@ HyperHdrDaemon::HyperHdrDaemon(const QString& rootPath, QObject* parent, bool lo
 
 void HyperHdrDaemon::instanceStateChanged(InstanceState state, quint8 instance, const QString& name)
 {
+	// start web server if needed
+	if (state == InstanceState::H_STARTED)
+	{
+		if (_webserver != nullptr && !_webserver->thread()->isRunning())
+			_webserver->thread()->start();
+		if (_sslWebserver != nullptr && !_sslWebserver->thread()->isRunning())
+			_sslWebserver->thread()->start();
+	}
+
 	// cec
 	updateCEC();
 }
@@ -331,7 +340,6 @@ void HyperHdrDaemon::startNetworkServices()
 	connect(wsThread, &QThread::started, _webserver, &WebServer::initServer);
 	connect(wsThread, &QThread::finished, _webserver, &WebServer::deleteLater);
 	connect(this, &HyperHdrDaemon::settingsChanged, _webserver, &WebServer::handleSettingsUpdate);
-	wsThread->start();
 
 	// Create SSL Webserver in thread
 	_sslWebserver = new WebServer(getSetting(settings::type::WEBSERVER), true);
@@ -341,7 +349,6 @@ void HyperHdrDaemon::startNetworkServices()
 	connect(sslWsThread, &QThread::started, _sslWebserver, &WebServer::initServer);
 	connect(sslWsThread, &QThread::finished, _sslWebserver, &WebServer::deleteLater);
 	connect(this, &HyperHdrDaemon::settingsChanged, _sslWebserver, &WebServer::handleSettingsUpdate);
-	sslWsThread->start();
 
 	// Create SSDP server in thread
 	_ssdp = new SSDPHandler(_webserver,

--- a/sources/hyperhdr/hyperhdr.h
+++ b/sources/hyperhdr/hyperhdr.h
@@ -119,11 +119,6 @@ public:
 	~HyperHdrDaemon();
 
 	///
-	/// @brief Get webserver pointer (systray)
-	///
-	WebServer* getWebServerInstance() { return _webserver; }
-
-	///
 	/// @brief get the settings
 	///
 	QJsonDocument getSetting(settings::type type) const;


### PR DESCRIPTION
Currently, the start of the http & https webserver was not synchronized with the start of the proper instance. This led to non-critical deadlocks when the HyperHDR website was opened by the user and the HyperHDR was restarted at the same time. After reloading the page, it was also possible to select the wrong instance. The patch synchronizes the start of the web server when the instance is ready for use.