### PR TITLE
Fix: Automatic signal detection timing

### DIFF
--- a/sources/base/DetectionAutomatic.cpp
+++ b/sources/base/DetectionAutomatic.cpp
@@ -516,9 +516,15 @@ bool DetectionAutomatic::checkSignal(Image<ColorRgb>& image)
 	bool hasSignal = (finalQuality <= _modelTolerance);
 
 	if (!hasSignal && _noSignal)
+	{
+		_onSignalTime = 0;
 		return false;
+	}
 	if (hasSignal && !_noSignal)
+	{
+		_offSignalTime = 0;
 		return true;
+	}
 
 	qint64 time = InternalClock::now();
 

--- a/sources/base/DetectionAutomatic.cpp
+++ b/sources/base/DetectionAutomatic.cpp
@@ -551,6 +551,8 @@ bool DetectionAutomatic::checkSignal(Image<ColorRgb>& image)
 
 		return true;
 	}
+	else
+		_offSignalTime = 0;
 
 	if (hasSignal && _noSignal)
 	{

--- a/sources/base/DetectionAutomatic.cpp
+++ b/sources/base/DetectionAutomatic.cpp
@@ -578,6 +578,8 @@ bool DetectionAutomatic::checkSignal(Image<ColorRgb>& image)
 
 		return false;
 	}
+	else
+		_onSignalTime = 0;
 
 	return true;
 }


### PR DESCRIPTION
If the 'signal lost detection' is triggered by a frame, but next frames don't confirm it and cancel the event, then after some time next single frame that matches no-signal board can trigger no-signal event immediately (ignoring Automatic Detection 'Sleep time' settings).
A similar situation happens when waking-procedure (on signal restored) is interrupted, then the next single frame can wake up HyperHDR immediately (ignoring Automatic Detection 'Wake time' settings).

Usually can happen for noisy input when the HyperHDR was calibrated for black no-signal board. So single black video frames could sudden trigger false 'no-signal' event.