### PR TITLE
Fix disabled leds

### DIFF
--- a/assets/webconfig/js/light_source.js
+++ b/assets/webconfig/js/light_source.js
@@ -700,6 +700,10 @@ $(document).ready(function()
 				"group": {
 					"type": "integer",
 					"minimum": 0					
+				},
+				"disabled": {
+					"type": "boolean",
+					"default": false
 				}
 			},
 			"type": "object"
@@ -950,7 +954,9 @@ $(document).ready(function()
 	// validate textfield and update preview
 	$("#leds_custom_updsim").off().on("click", function()
 	{
-		createLedPreview(aceEdt.get(), 'text');
+		const backup = aceEdt.get();
+		createLedPreview(backup, 'text');
+		aceEdt.set(backup);
 	});
 
 	// save led config and saveValues - passing textfield

--- a/include/base/ImageToLedsMap.h
+++ b/include/base/ImageToLedsMap.h
@@ -88,12 +88,10 @@ namespace hyperhdr
 
 		/// The absolute indices into the image for each led
 		std::vector<std::vector<int32_t>> _colorsMap;
-		std::vector<bool> _colorsDisabled;
 		std::vector<int> _colorsGroups;
 
 		int _groupMin;
 		int _groupMax;
-		bool _haveDisabled;
 
 		ColorRgb calcMeanColor(const Image<ColorRgb>& image, const std::vector<int32_t>& colors) const;
 

--- a/include/base/LedString.h
+++ b/include/base/LedString.h
@@ -130,6 +130,8 @@ public:
 	/// the color order
 	ColorOrder colorOrder = ColorOrder::ORDER_RGB;
 
+	bool hasDisabled = false;
+
 	static ColorOrder createColorOrder(const QJsonObject& deviceConfig);
 	static LedString createLedString(const QJsonArray& ledConfigArray, const ColorOrder deviceOrder);
 	static QSize getLedLayoutGridSize(const QJsonArray& ledConfigArray);

--- a/sources/base/HyperHdrInstance.cpp
+++ b/sources/base/HyperHdrInstance.cpp
@@ -444,6 +444,9 @@ bool HyperHdrInstance::setInputInactive(quint8 priority)
 
 void HyperHdrInstance::setColor(int priority, const std::vector<ColorRgb>& ledColors, int timeout_ms, const QString& origin, bool clearEffects)
 {
+	if (ledColors.size() == 0)
+		return;
+
 	// clear effect if this call does not come from an effect
 	if (clearEffects)
 	{
@@ -451,20 +454,16 @@ void HyperHdrInstance::setColor(int priority, const std::vector<ColorRgb>& ledCo
 	}
 
 	// create full led vector from single/multiple colors
-	size_t size = _ledString.leds().size();
 	std::vector<ColorRgb> newLedColors;
-	while (true)
+	auto currentCol = ledColors.begin();
+
+	while (newLedColors.size() < _ledString.leds().size())
 	{
-		for (const auto& entry : ledColors)
-		{
-			newLedColors.emplace_back(entry);
-			if (newLedColors.size() == size)
-			{
-				goto end;
-			}
-		}
+		newLedColors.emplace_back(*currentCol);
+
+		if (++currentCol == ledColors.end())
+			currentCol = ledColors.begin();
 	}
-end:
 
 	if (getPriorityInfo(priority).componentId != hyperhdr::COMP_COLOR)
 	{
@@ -672,37 +671,55 @@ void HyperHdrInstance::updateResult(std::vector<ColorRgb> _ledBuffer)
 
 	_globalLedBuffer = _ledBuffer;
 
-	// emit rawLedColors before transform
-	emit rawLedColors(_ledBuffer);
-
-	_raw2ledAdjustment->applyAdjustment(_ledBuffer);
-
-	for (ColorRgb& color : _ledBuffer)
+	for (int disabledProcessing = 0; disabledProcessing < 2; disabledProcessing++)
 	{
-		// correct the color byte order
-		switch (_ledString.colorOrder)
-		{
-			case ColorOrder::ORDER_RGB:
-				// leave as it is
-				break;
-			case ColorOrder::ORDER_BGR:
-				std::swap(color.red, color.blue);
-				break;
-			case ColorOrder::ORDER_RBG:
-				std::swap(color.green, color.blue);
-				break;
-			case ColorOrder::ORDER_GRB:
-				std::swap(color.red, color.green);
-				break;
-			case ColorOrder::ORDER_GBR:
-				std::swap(color.red, color.green);
-				std::swap(color.green, color.blue);
-				break;
+		if (disabledProcessing == 1)
+			_raw2ledAdjustment->applyAdjustment(_ledBuffer);
 
-			case ColorOrder::ORDER_BRG:
-				std::swap(color.red, color.blue);
-				std::swap(color.green, color.blue);
-				break;
+		if (_ledString.hasDisabled)
+		{
+			auto ledIter = _ledString.leds().begin();
+			for (ColorRgb& color : _ledBuffer)
+				if (ledIter != _ledString.leds().end())
+				{
+					if ((*ledIter).disabled)
+						color = ColorRgb::BLACK;
+					++ledIter;
+				}
+		}
+
+		if (disabledProcessing == 0)
+			emit rawLedColors(_ledBuffer);	
+	}
+
+	if (_ledString.colorOrder != ColorOrder::ORDER_RGB)
+	{
+		for (ColorRgb& color : _ledBuffer)
+		{
+			// correct the color byte order
+			switch (_ledString.colorOrder)
+			{
+				case ColorOrder::ORDER_RGB:
+					break;
+				case ColorOrder::ORDER_BGR:
+					std::swap(color.red, color.blue);
+					break;
+				case ColorOrder::ORDER_RBG:
+					std::swap(color.green, color.blue);
+					break;
+				case ColorOrder::ORDER_GRB:
+					std::swap(color.red, color.green);
+					break;
+				case ColorOrder::ORDER_GBR:
+					std::swap(color.red, color.green);
+					std::swap(color.green, color.blue);
+					break;
+
+				case ColorOrder::ORDER_BRG:
+					std::swap(color.red, color.blue);
+					std::swap(color.green, color.blue);
+					break;
+			}
 		}
 	}
 

--- a/sources/base/ImageToLedsMap.cpp
+++ b/sources/base/ImageToLedsMap.cpp
@@ -20,11 +20,9 @@ ImageToLedsMap::ImageToLedsMap(
 	, _horizontalBorder(horizontalBorder)
 	, _verticalBorder(verticalBorder)
 	, _colorsMap()
-	, _colorsDisabled()
 	, _colorsGroups()
 	, _groupMin(-1)
 	, _groupMax(-1)
-	, _haveDisabled(false)
 {
 	// Sanity check of the size of the borders (and width and height)
 	Q_ASSERT(_width > 2 * _verticalBorder);
@@ -174,9 +172,7 @@ ImageToLedsMap::ImageToLedsMap(
 		}
 
 		// Add the constructed vector to the map
-		_haveDisabled |= led.disabled;
 		_colorsMap.push_back(ledColor);
-		_colorsDisabled.push_back(led.disabled);
 		_colorsGroups.push_back(led.group);
 		if (_groupMin == -1 || led.group < _groupMin)
 			_groupMin = led.group;
@@ -254,15 +250,7 @@ std::vector<ColorRgb> ImageToLedsMap::Process(const Image<ColorRgb>& image, uint
 				}
 		}
 	}
-
-	for (size_t i = 0; _haveDisabled && i < qMin(_colorsDisabled.size(), colors.size()); i++)
-		if (_colorsDisabled[i])
-		{
-			colors[i].red = 0;
-			colors[i].green = 0;
-			colors[i].blue = 0;
-		}
-
+	
 	return colors;
 }
 

--- a/sources/base/LedString.cpp
+++ b/sources/base/LedString.cpp
@@ -25,6 +25,7 @@ LedString LedString::createLedString(const QJsonArray& ledConfigArray, const Col
 	LedString ledString;
 	const QString deviceOrderStr = colorOrderToString(deviceOrder);
 
+	ledString.hasDisabled = false;
 	for (signed i = 0; i < ledConfigArray.size(); ++i)
 	{
 		const QJsonObject& ledConfig = ledConfigArray[i].toObject();
@@ -36,6 +37,7 @@ LedString LedString::createLedString(const QJsonArray& ledConfigArray, const Col
 		led.maxY_frac = qMax(0.0, qMin(1.0, ledConfig["vmax"].toDouble()));
 		led.group = ledConfig["group"].toInt(0);
 		led.disabled = ledConfig["disabled"].toBool(false);
+		ledString.hasDisabled |= led.disabled;
 
 		// Fix if the user swapped min and max
 		if (led.minX_frac > led.maxX_frac)

--- a/sources/base/LinearSmoothing.cpp
+++ b/sources/base/LinearSmoothing.cpp
@@ -208,7 +208,7 @@ void LinearSmoothing::updateLedValues(const std::vector<ColorRgb>& ledValues)
 		if (_pause || ledValues.size() == 0)
 			return;
 
-		emit _hyperhdr->ledDeviceData(ledValues);
+		queueColors(ledValues);
 
 		return;
 	}


### PR DESCRIPTION
Fix some issues related to disabled leds
1) LED post processing/color calibration could override the black color (e.g. 'Backlight threshold')
2) JSONACEEditor schema not updated to include new "disabled" property causing errors when manually editing

Fixes  #418