### PR TITLE
Add support for utv007 / Linux

### DIFF
--- a/sources/base/schema/schema-color.json
+++ b/sources/base/schema/schema-color.json
@@ -13,7 +13,7 @@
 			"options" : {
 				"enum_titles" : ["edt_conf_enum_multicolor_mean", "edt_conf_enum_unicolor_mean", "edt_conf_enum_unicolor_advanced", "edt_conf_enum_unicolor_weighted"]
 			},
-			"default"  : "advanced",
+			"default"  : "multicolor_mean",
 			"propertyOrder" : 1
 		},
 		"sparse_processing" :
@@ -60,7 +60,7 @@
 						"type" : "boolean",
 						"format": "checkbox",
 						"title" : "edt_conf_color_classic_config_title",
-						"default" : true,
+						"default" : false,
 						"required" : true,
 						"propertyOrder" : 3
 					},

--- a/sources/grabber/v4l2/V4L2Grabber.cpp
+++ b/sources/grabber/v4l2/V4L2Grabber.cpp
@@ -544,6 +544,7 @@ void V4L2Grabber::enumerateV4L2devices(bool silent)
 			// UTV007 workaround
 			if (properties.valid.size() == 0 && realName.indexOf("usbtv ", 0, Qt::CaseInsensitive) == 0)
 			{
+				Warning(_log, "To have proper colors when using UTV007 grabber, you may need to add 'sudo systemctl stop hyperhdr@pi && v4l2-ctl -s pal-B && sudo systemctl start hyperhdr@pi' to /etc/rc.local or run it manually to set the PAL standard");
 				{ DevicePropertiesItem diL; diL.x = 320; diL.y = 240; diL.fps = 30; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }
 				{ DevicePropertiesItem diL; diL.x = 320; diL.y = 288; diL.fps = 25; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }
 				{ DevicePropertiesItem diL; diL.x = 360; diL.y = 240; diL.fps = 30; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }

--- a/sources/grabber/v4l2/V4L2Grabber.cpp
+++ b/sources/grabber/v4l2/V4L2Grabber.cpp
@@ -540,6 +540,17 @@ void V4L2Grabber::enumerateV4L2devices(bool silent)
 
 				devNameFile.close();
 			}
+
+			// UTV007 workaround
+			if (properties.valid.size() == 0 && realName.indexOf("usbtv ", 0, Qt::CaseInsensitive) == 0)
+			{
+				{ DevicePropertiesItem diL; diL.x = 320; diL.y = 240; diL.fps = 30; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }
+				{ DevicePropertiesItem diL; diL.x = 320; diL.y = 288; diL.fps = 25; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }
+				{ DevicePropertiesItem diL; diL.x = 360; diL.y = 240; diL.fps = 30; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }
+				{ DevicePropertiesItem diL; diL.x = 720; diL.y = 480; diL.fps = 30; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }
+				{ DevicePropertiesItem diL; diL.x = 720; diL.y = 576; diL.fps = 25; diL.pf = identifyFormat(V4L2_PIX_FMT_YUYV); diL.v4l2PixelFormat = V4L2_PIX_FMT_YUYV; diL.input = 0; properties.valid.append(diL); }
+			}
+
 			_deviceProperties.insert(realName, properties);
 
 			if (!silent)


### PR DESCRIPTION
Add support for old analog grabber utv007. To control old analog switches like PAL/SECAM standard use ```v4l2-ctl``` (-s parameter, the capturing must be stopped before) Linux command. For example:  
`sudo systemctl stop hyperhdr@pi && v4l2-ctl -s pal-B && sudo systemctl start hyperhdr@pi`

![obraz](https://user-images.githubusercontent.com/69086569/202918421-26739f31-c2f4-4930-9f35-3b067d73b858.png)

**Resolution 720x576 is for PAL only. Otherwise you may encounter problems when capturing NTSC standard.**

Fixes #422 
Fixes #421