### PR TITLE
Esp8266/ESP32 reset handshake for the serial connection

### DIFF
--- a/assets/webconfig/i18n/en.json
+++ b/assets/webconfig/i18n/en.json
@@ -1188,5 +1188,6 @@
   "led_editor_context_moving": "Left click the mouse to accept the position",
   "conf_leds_disabled_notification" : "Some LEDs are disabled by the user!",
   "conf_leds_layout_context" : "Right click on the LED to display the context menu. With the CTRL key selects the object below.",
-  "conf_leds_layout_btn_zoom" : "Zoom"
+  "conf_leds_layout_btn_zoom" : "Zoom",
+  "edt_serial_espHandshake" : "Esp8266/ESP32 handshake"
 } 

--- a/sources/leddevice/dev_serial/ProviderRs232.h
+++ b/sources/leddevice/dev_serial/ProviderRs232.h
@@ -97,6 +97,9 @@ protected slots:
 	///
 	void setInError(const QString& errorMsg) override;
 
+public slots:
+	void waitForExitStats();
+
 private:
 
 	///
@@ -114,6 +117,8 @@ private:
 
 	/// Frames dropped, as write failed
 	int _frameDropCounter;
+
+	bool _espHandshake;
 };
 
 #endif // PROVIDERRS232_H

--- a/sources/leddevice/schemas/schema-adalight.json
+++ b/sources/leddevice/schemas/schema-adalight.json
@@ -21,6 +21,20 @@
 			"default": 2000000,			
 			"propertyOrder" : 3
 		},
+		"espHandshake" :
+		{
+			"type" : "boolean",
+			"format": "checkbox",
+			"title" : "edt_serial_espHandshake",		
+			"default" : true,
+			"required" : true,
+			"options": {
+				"dependencies": {
+					"awa_mode": true
+				}
+			},
+			"propertyOrder" : 4
+		},
 		"white_channel_calibration": {
 			"type": "boolean",
 			"format": "checkbox",
@@ -32,7 +46,7 @@
 					"awa_mode": true
 				}
 			},
-			"propertyOrder" : 4
+			"propertyOrder" : 5
 		},
 		"white_channel_limit": {
 			"type": "number",
@@ -49,7 +63,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 5
+			"propertyOrder" : 6
 		},
 		"white_channel_red": {
 			"type": "integer",
@@ -65,7 +79,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 6
+			"propertyOrder" : 7
 		},
 		"white_channel_green": {
 			"type": "integer",
@@ -81,7 +95,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 7
+			"propertyOrder" : 8
 		},
 		"white_channel_blue": {
 			"type": "integer",
@@ -97,7 +111,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 8
+			"propertyOrder" : 9
 		},
 		"delayAfterConnect": {
 			"type": "integer",
@@ -110,7 +124,7 @@
 					"awa_mode": false
 				}
 			},
-			"propertyOrder" : 9
+			"propertyOrder" : 10
 		},
 		"lightberry_apa102_mode": {
 			"type": "boolean",
@@ -123,7 +137,7 @@
 					"awa_mode": false
 				}
 			},
-			"propertyOrder" : 10
+			"propertyOrder" : 11
 		}
 	},
 	"additionalProperties": true


### PR DESCRIPTION
In certain circumstance ESP device could be left in unspecified state. This PR add following new option:
![obraz](https://user-images.githubusercontent.com/69086569/205159682-cc6f661f-16d5-4eaf-8183-cbf71fd48183.png)

that allows:
- reset the ESP32/Esp8266 board at the beginning
- after the reset is performed, we read the initial HyperSerialEsp8266/HyperSerialESP32 boot message and check it
![obraz](https://user-images.githubusercontent.com/69086569/205159989-b6550c5f-52f7-4608-800d-ece7f497e799.png)

- if the board is not capable of the 2Mb speed (or any other speed set in HyperHDR) the user will see a warning 
![obraz](https://user-images.githubusercontent.com/69086569/205162012-1de8fa07-9029-43a3-8a65-c5970f21fb4b.png)

- after the LED device is stopper, we read the statistics (just wait few seconds). Still we maintain one way communication at the same time, because of problems with the performance of duplex for certain system/drivers. 
![obraz](https://user-images.githubusercontent.com/69086569/205161035-e0be7b4a-683e-477f-905b-3030b2541f1f.png)

![obraz](https://user-images.githubusercontent.com/69086569/205160361-2a26d880-0e38-4d32-add0-bcc6c297adf9.png)

  
--------------------------------------------------------------------------------------------------------------  

Also please check out other new feature added in the previous commit, that shows how many frames were dropped due to slow LED device or too high refresh rate set in the smoothing:

![obraz](https://user-images.githubusercontent.com/69086569/205162581-b6258af3-0636-4e41-a7aa-59235c3ab034.png)
