### PR TITLE
ESP32-S2 mini support (Adalight AWA protocol)

### DIFF
--- a/.github/workflows/image-builder-from-repo.yml
+++ b/.github/workflows/image-builder-from-repo.yml
@@ -63,12 +63,12 @@ jobs:
         echo 'set -x' >> start_chroot_script
         echo 'set -e' >> start_chroot_script
         echo 'source /common.sh' >> start_chroot_script        
-        echo 'type -p curl >/dev/null || sudo apt install curl -y' >> start_chroot_script
-        echo 'curl -fsSL https://awawa-dev.github.io/hyperhdr.public.apt.gpg.key | sudo dd of=/usr/share/keyrings/hyperhdr.public.apt.gpg.key \' >> start_chroot_script
-        echo '&& sudo chmod go+r /usr/share/keyrings/hyperhdr.public.apt.gpg.key \' >> start_chroot_script
-        echo '&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hyperhdr.public.apt.gpg.key] https://awawa-dev.github.io $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hyperhdr.list > /dev/null \' >> start_chroot_script
-        echo '&& sudo apt update \' >> start_chroot_script
-        echo '&& sudo apt install hyperhdr -y' >> start_chroot_script        
+        echo 'type -p curl >/dev/null || apt install curl -y' >> start_chroot_script
+        echo 'curl -fsSL https://awawa-dev.github.io/hyperhdr.public.apt.gpg.key | dd of=/usr/share/keyrings/hyperhdr.public.apt.gpg.key \' >> start_chroot_script
+        echo '&& chmod go+r /usr/share/keyrings/hyperhdr.public.apt.gpg.key \' >> start_chroot_script
+        echo '&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hyperhdr.public.apt.gpg.key] https://awawa-dev.github.io $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hyperhdr.list > /dev/null \' >> start_chroot_script
+        echo '&& apt update \' >> start_chroot_script
+        echo '&& apt install hyperhdr -y' >> start_chroot_script        
         echo 'touch /boot/ssh' >> start_chroot_script
         echo "echo -n 'pi:' > /boot/userconf" >> start_chroot_script
         echo "echo 'raspberry' | openssl passwd -6 -stdin >> /boot/userconf" >> start_chroot_script

--- a/sources/leddevice/dev_serial/EspTools.h
+++ b/sources/leddevice/dev_serial/EspTools.h
@@ -1,0 +1,108 @@
+/* EspTools.h
+*
+*  MIT License
+*
+*  Copyright (c) 2022 awawa-dev
+*
+*  Project homesite: https://github.com/awawa-dev/HyperHDR
+*
+*  Permission is hereby granted, free of charge, to any person obtaining a copy
+*  of this software and associated documentation files (the "Software"), to deal
+*  in the Software without restriction, including without limitation the rights
+*  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*  copies of the Software, and to permit persons to whom the Software is
+*  furnished to do so, subject to the following conditions:
+*
+*  The above copyright notice and this permission notice shall be included in all
+*  copies or substantial portions of the Software.
+
+*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*  SOFTWARE.
+ */
+
+#ifndef ESPTOOLS_H
+#define ESPTOOLS_H
+
+class EspTools
+{
+	public:
+
+	static void goingSleep(QSerialPort& _rs232Port)
+	{
+		uint8_t comBuffer[] = { 0x41, 0x77, 0x41, 0x2a, 0xa2, 0x35, 0x68, 0x79, 0x70, 0x65, 0x72, 0x68, 0x64, 0x72 };
+		_rs232Port.write((char*)comBuffer, sizeof(comBuffer));
+		_rs232Port.flush();
+		_rs232Port.clear();
+	}
+
+	static void initializeEsp(QSerialPort& _rs232Port, QSerialPortInfo& serialPortInfo, Logger*& _log)
+	{
+		if (serialPortInfo.productIdentifier() == 0x80c2 && serialPortInfo.vendorIdentifier() == 0x303a)
+		{
+			Warning(_log, "Detected ESP32-S2 lolin mini type board. HyperHDR skips the reset. State: %i, %i",
+				_rs232Port.isDataTerminalReady(), _rs232Port.isRequestToSend());
+
+			uint8_t comBuffer[] = { 0x41, 0x77, 0x41, 0x2a, 0xa2, 0x15, 0x68, 0x79, 0x70, 0x65, 0x72, 0x68, 0x64, 0x72 };
+			_rs232Port.write((char*)comBuffer, sizeof(comBuffer));
+
+			_rs232Port.setDataTerminalReady(true);
+			_rs232Port.setRequestToSend(true);
+			_rs232Port.setRequestToSend(false);			
+		}
+		else
+		{
+			// reset to defaults
+			_rs232Port.setDataTerminalReady(true);
+			_rs232Port.setRequestToSend(false);
+			QThread::msleep(50);
+
+			// reset device
+			_rs232Port.setDataTerminalReady(false);
+			_rs232Port.setRequestToSend(true);
+			QThread::msleep(100);
+
+			// resume device
+			_rs232Port.setRequestToSend(false);
+			QThread::msleep(100);
+		}
+
+		// read the reset message, search for AWA tag
+		auto start = InternalClock::now();
+
+		while (InternalClock::now() - start < 1000)
+		{
+			_rs232Port.waitForReadyRead(100);
+			if (_rs232Port.bytesAvailable() > 16)
+			{
+				auto incoming = _rs232Port.readAll();
+				for (int i = 0; i < incoming.length(); i++)
+					if (!(incoming[i] == '\n' ||
+						(incoming[i] >= ' ' && incoming[i] <= 'Z') ||
+						(incoming[i] >= 'a' && incoming[i] <= 'z')))
+					{
+						incoming.replace(incoming[i], '*');
+					}
+				QString result = QString(incoming).remove('*').replace('\n', ' ').trimmed();
+				if (result.indexOf("Awa driver", Qt::CaseInsensitive) >= 0)
+				{
+					Info(_log, "DETECTED DEVICE USING HYPERSERIALESP8266/HYPERSERIALESP32 FIRMWARE (%s) at %i msec", QSTRING_CSTR(result), int(InternalClock::now() - start));
+					start = 0;
+					break;
+				}
+			}
+
+			if (InternalClock::now() <= start)
+				break;
+		}
+
+		if (start != 0)
+			Error(_log, "Could not detect HyperSerialEsp8266/HyperSerialESP32 device");
+	}
+};
+
+#endif

--- a/sources/leddevice/dev_serial/ProviderRs232.h
+++ b/sources/leddevice/dev_serial/ProviderRs232.h
@@ -98,7 +98,7 @@ protected slots:
 	void setInError(const QString& errorMsg) override;
 
 public slots:
-	void waitForExitStats();
+	void waitForExitStats(bool force);
 
 private:
 


### PR DESCRIPTION
Add support for esp32-s2 mini CDC board 'esp8266/esp32 handshake' in the Adalight driver properties. Needs firmware HyperSerialESP32 v8 (https://github.com/awawa-dev/HyperSerialESP32/pull/10)
