### PR TITLE
Use longer reset pulse

### DIFF
--- a/sources/leddevice/dev_serial/EspTools.h
+++ b/sources/leddevice/dev_serial/EspTools.h
@@ -64,7 +64,7 @@ class EspTools
 			// reset device
 			_rs232Port.setDataTerminalReady(false);
 			_rs232Port.setRequestToSend(true);
-			QThread::msleep(100);
+			QThread::msleep(150);
 
 			// resume device
 			_rs232Port.setRequestToSend(false);
@@ -94,10 +94,7 @@ class EspTools
 					start = 0;
 					break;
 				}
-			}
-
-			if (InternalClock::now() <= start)
-				break;
+			}			
 		}
 
 		if (start != 0)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Use longer reset pulse to make sure that esp is completely reseted
Fixes https://github.com/awawa-dev/HyperSerialESP32/issues/13



**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated (docs/docs/en)
- [ ] Related tests have been updated

**PLEASE DON'T FORGET TO ADD YOUR CHANGES TO CHANGELOG.MD**
- [ ] Yes, CHANGELOG.md is also updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
