### PR TITLE
Adalight: auto-resume and ESP8266/ESP32 auto-discovery

### DIFF
--- a/sources/leddevice/dev_serial/ProviderRs232.cpp
+++ b/sources/leddevice/dev_serial/ProviderRs232.cpp
@@ -52,12 +52,14 @@ bool ProviderRs232::init(const QJsonObject& deviceConfig)
 		_baudRate_Hz = deviceConfig["rate"].toInt();
 		_delayAfterConnect_ms = deviceConfig["delayAfterConnect"].toInt(0);
 		_espHandshake = deviceConfig["espHandshake"].toBool(false);
+		_maxRetry = _devConfig["maxRetry"].toInt(60);
 
 		Debug(_log, "Device name   : %s", QSTRING_CSTR(_deviceName));
 		Debug(_log, "Auto selection: %d", _isAutoDeviceName);
 		Debug(_log, "Baud rate     : %d", _baudRate_Hz);
 		Debug(_log, "ESP handshake : %s", (_espHandshake) ? "ON" : "OFF");
 		Debug(_log, "Delayed open  : %d", _delayAfterConnect_ms);
+		Debug(_log, "Retry limit   : %d", _maxRetry);
 
 		isInitOK = true;
 	}

--- a/sources/leddevice/schemas/schema-adalight.json
+++ b/sources/leddevice/schemas/schema-adalight.json
@@ -138,6 +138,18 @@
 				}
 			},
 			"propertyOrder" : 11
+		},
+		"maxRetry":
+		{
+			"type" : "integer",
+			"format" : "stepper",			
+			"step"   : 1,			
+			"title" : "edt_dev_max_retry",
+			"minimum" : 0,
+			"maximum" : 120,
+			"default" : 0,
+			"required" : true,
+			"propertyOrder" : 12
 		}
 	},
 	"additionalProperties": true


### PR DESCRIPTION
If `ESP32/Esp8266 handshake` is enabled and the user selects 'auto' in the device selection, HyperHDR will search for known ESP devices in the first place. 

Serial port re-discovery is triggered now every time the device is started for such configuration.

Auto resume mechanism can be enabled now for the Adalight.

![obraz](https://user-images.githubusercontent.com/69086569/215194900-e1613625-1602-40bc-875c-fa335bc6b93e.png)
