### PR TITLE
Fix for #562

### DIFF
--- a/sources/leddevice/dev_net/LedDeviceUdpRaw.cpp
+++ b/sources/leddevice/dev_net/LedDeviceUdpRaw.cpp
@@ -25,5 +25,8 @@ int LedDeviceUdpRaw::write(const std::vector<ColorRgb>& ledValues)
 {
 	const uint8_t* dataPtr = reinterpret_cast<const uint8_t*>(ledValues.data());
 
+	if (ledValues.size() != _ledCount)
+		setLedCount(ledValues.size());
+
 	return writeBytes(_ledRGBCount, dataPtr);
 }

--- a/sources/leddevice/dev_net/LedDeviceWled.cpp
+++ b/sources/leddevice/dev_net/LedDeviceWled.cpp
@@ -309,5 +309,8 @@ int LedDeviceWled::write(const std::vector<ColorRgb>& ledValues)
 {
 	const uint8_t* dataPtr = reinterpret_cast<const uint8_t*>(ledValues.data());
 
+	if (ledValues.size() != _ledCount)
+		setLedCount(ledValues.size());
+
 	return writeBytes(_ledRGBCount, dataPtr);
 }


### PR DESCRIPTION
Fix wled/udpraw proper buffer size when LED number has been changed in the current session.
Fixes #562 