### PR TITLE
Workaround for Rpi udev critical bug

### DIFF
--- a/sources/leddevice/dev_serial/EspTools.h
+++ b/sources/leddevice/dev_serial/EspTools.h
@@ -64,6 +64,17 @@ class EspTools
 			_rs232Port.setRequestToSend(true);
 			_rs232Port.setRequestToSend(false);			
 		}
+		else if (serialPortInfo.productIdentifier() == 0x3483 && serialPortInfo.vendorIdentifier() == 0x1106)
+		{
+			Warning(_log, "Enabling the Rpi4 udev bug workaround. The serial device is incorrectly identified by the OS and HyperHDR skips the reset. State: %i, %i",
+				_rs232Port.isDataTerminalReady(), _rs232Port.isRequestToSend());
+
+			_rs232Port.write((char*)comBuffer, sizeof(comBuffer));
+
+			_rs232Port.setDataTerminalReady(true);
+			_rs232Port.setRequestToSend(true);
+			_rs232Port.setRequestToSend(false);
+		}
 		else
 		{
 			// reset to defaults


### PR DESCRIPTION
There is currently a critical bug in the udev module that causes serial devices to be misidentified.
Affects HyperSerial8266/HyperSerialESP32/HyperSerialPico devices especially using Raspberry Pi OS arm64 with kernel 6.
HyperHDR SD v19 images work fine if the system is not updated.

This PR provides a workaround on Rpi4 for 'esp8266/esp32/rp2040 handshake' in the Adalight driver until it is fixed in the upstream.
Automatic device detection will not work, so the correct path for the serial device must be manually selected from the list.
Read more:
1) https://bugreports.qt.io/browse/QTBUG-113462
2) https://github.com/awawa-dev/HyperHDR/discussions/561#discussioncomment-5994170
