### PR TITLE
Add updateDelay to LinearSmoothing

### DIFF
--- a/include/base/HyperHdrInstance.h
+++ b/include/base/HyperHdrInstance.h
@@ -95,7 +95,7 @@ public:
 	int getLedMappingType() const;
 
 	/// forward smoothing config
-	unsigned updateSmoothingConfig(unsigned id, int settlingTime_ms = 200, double ledUpdateFrequency_hz = 25.0, bool directMode = false);
+	unsigned updateSmoothingConfig(unsigned id, int settlingTime_ms = 200, int updateDelay_ms = 0, double ledUpdateFrequency_hz = 25.0, bool directMode = false);
 
 	///
 	/// @brief Get the current active led device

--- a/include/base/LinearSmoothing.h
+++ b/include/base/LinearSmoothing.h
@@ -78,12 +78,13 @@ public slots:
 	///
 	/// @param   cfgID				   Smoothing configuration item to be updated
 	/// @param   settlingTime_ms       The buffer time
+	/// @param   updateDelay_ms        The update delay
 	/// @param   ledUpdateFrequency_hz The frequency of update
 	/// @param   updateDelay           The delay
 	///
 	/// @return The index of the cfg which can be passed to selectConfig()
 	///
-	unsigned updateConfig(unsigned cfgID, int settlingTime_ms, double ledUpdateFrequency_hz, bool directModee);
+	unsigned updateConfig(unsigned cfgID, int settlingTime_ms, int updateDelay_ms, double ledUpdateFrequency_hz, bool directModee);
 
 	void updateCurrentConfig(int settlingTime_ms);
 private:
@@ -102,12 +103,13 @@ private:
 	///
 	/// @brief Add a new smoothing cfg which can be used with selectConfig()
 	/// @param   settlingTime_ms       The buffer time
+	/// @param   updateDelay_ms        The update delay
 	/// @param   ledUpdateFrequency_hz The frequency of update
 	/// @param   updateDelay           The delay
 	///
 	/// @return The index of the cfg which can be passed to selectConfig()
 	///
-	unsigned addConfig(int settlingTime_ms, double ledUpdateFrequency_hz = 25.0, bool directMode = false);
+	unsigned addConfig(int settlingTime_ms, int updateDelay_ms = 0, double ledUpdateFrequency_hz = 25.0, bool directMode = false);
 
 	uint8_t clamp(int x);
 
@@ -127,6 +129,9 @@ private:
 
 	/// The interval at which to update the leds (msec)
 	int64_t _updateInterval;
+
+	/// The time before which the updated led values start to be applied (msec)
+	int64_t _updateDelay;
 
 	/// The time after which the updated led values have been fully applied (msec)
 	int64_t _settlingTime;
@@ -166,6 +171,7 @@ private:
 	public:
 		bool		  _pause;
 		int64_t		  _settlingTime;
+		int64_t       _updateDelay;
 		int64_t		  _updateInterval;
 		bool		  _directMode;
 		SmoothingType _type;
@@ -175,7 +181,7 @@ private:
 
 		SmoothingCfg();
 
-		SmoothingCfg(bool pause, int64_t settlingTime, int64_t updateInterval, bool directMode, SmoothingType type = SmoothingType::Linear, int antiFlickeringTreshold = 0, int antiFlickeringStep = 0, int64_t antiFlickeringTimeout = 0);
+		SmoothingCfg(bool pause, int64_t settlingTime, int64_t updateDelay, int64_t updateInterval, bool directMode, SmoothingType type = SmoothingType::Linear, int antiFlickeringTreshold = 0, int antiFlickeringStep = 0, int64_t antiFlickeringTimeout = 0);
 
 		static QString EnumToString(SmoothingType type);
 	};

--- a/sources/base/HyperHdrInstance.cpp
+++ b/sources/base/HyperHdrInstance.cpp
@@ -315,15 +315,15 @@ void HyperHdrInstance::setSmoothing(int time)
 	_smoothing->updateCurrentConfig(time);
 }
 
-unsigned HyperHdrInstance::updateSmoothingConfig(unsigned id, int settlingTime_ms, double ledUpdateFrequency_hz, bool directMode)
+unsigned HyperHdrInstance::updateSmoothingConfig(unsigned id, int settlingTime_ms, int updateDelay_ms, double ledUpdateFrequency_hz, bool directMode)
 {
 	unsigned retVal = id;
 
 	if (QThread::currentThread() == _smoothing->thread())
-		return _smoothing->updateConfig(id, settlingTime_ms, ledUpdateFrequency_hz, directMode);
+		return _smoothing->updateConfig(id, settlingTime_ms, updateDelay_ms, ledUpdateFrequency_hz, directMode);
 	else
 		QMetaObject::invokeMethod(_smoothing, "updateConfig",Qt::ConnectionType::BlockingQueuedConnection,
-			Q_RETURN_ARG(unsigned, retVal), Q_ARG(unsigned, id), Q_ARG(int, settlingTime_ms), Q_ARG(double, ledUpdateFrequency_hz), Q_ARG(bool, directMode));
+			Q_RETURN_ARG(unsigned, retVal), Q_ARG(unsigned, id), Q_ARG(int, settlingTime_ms), Q_ARG(int, updateDelay_ms), Q_ARG(double, ledUpdateFrequency_hz), Q_ARG(bool, directMode));
 	
 	return retVal;
 }

--- a/sources/base/schema/schema-smoothing.json
+++ b/sources/base/schema/schema-smoothing.json
@@ -37,6 +37,19 @@
 			"required" : true,
 			"propertyOrder" : 3
 		},
+		"updateDelay" :
+		{
+			"type" : "integer",
+			"format": "stepper",
+			"step" : 1,
+			"title" : "edt_conf_smooth_updateDelay_title",
+			"minimum" : 0,
+			"maximum": 5000,
+			"default" : 0,
+			"append" : "edt_append_ms",
+			"required" : true,
+			"propertyOrder" : 4
+		},
 		"updateFrequency" :
 		{
 			"type" : "number",
@@ -48,7 +61,7 @@
 			"default" : 50,
 			"append" : "edt_append_hz",
 			"required" : true,
-			"propertyOrder" : 4
+			"propertyOrder" : 5
 		},
 		"lowLightAntiFlickeringTreshold" :
 		{
@@ -60,7 +73,7 @@
 			"maximum": 255,
 			"default" : 32,
 			"required" : true,
-			"propertyOrder" : 5
+			"propertyOrder" : 6
 		},		
 		"lowLightAntiFlickeringValue" :
 		{
@@ -77,7 +90,7 @@
 				}
 			},
 			"required" : true,
-			"propertyOrder" : 6
+			"propertyOrder" : 7
 		},
 		"lowLightAntiFlickeringTimeout" :
 		{
@@ -95,7 +108,7 @@
 				}
 			},
 			"required" : true,
-			"propertyOrder" : 7
+			"propertyOrder" : 8
 		},
 		"continuousOutput" :
 		{
@@ -104,7 +117,7 @@
 			"title" : "edt_conf_smooth_continuousOutput_title",
 			"default" : false,
 			"required" : true,
-			"propertyOrder" : 10
+			"propertyOrder" : 11
 		}
 	},
 	"additionalProperties" : false


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Adds an updateDelay to LinearSmoothing as suggested in discussion https://github.com/awawa-dev/HyperHDR/discussions/542

I have verified this compiles but have not tested the functionality yet.

Hoping to get initial feedback on if this is the right approach.



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:


If changing the UI of web configuration, please provide the **before/after** screenshot:

<img width="364" alt="before" src="https://github.com/awawa-dev/HyperHDR/assets/1689668/4d9e9e0c-8bb6-45ab-a915-363ef3bdc0fe">

<img width="366" alt="after" src="https://github.com/awawa-dev/HyperHDR/assets/1689668/804fc508-9f96-400b-a265-0569323f3013">


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No
- [x] Not sure
