### PR TITLE
Workaround for QT reseting ESP UART board while restoring its state

### DIFF
--- a/sources/leddevice/dev_serial/EspTools.h
+++ b/sources/leddevice/dev_serial/EspTools.h
@@ -79,7 +79,9 @@ class EspTools
 		}
 		else
 		{
+#ifdef _WIN32
 			_restoreDTR = true;
+#endif
 
 			// reset to defaults
 			_rs232Port.setDataTerminalReady(true);

--- a/sources/leddevice/dev_serial/EspTools.h
+++ b/sources/leddevice/dev_serial/EspTools.h
@@ -42,6 +42,8 @@ class EspTools
 	{
 		uint8_t comBuffer[] = { 0x41, 0x77, 0x41, 0x2a, 0xa2, 0x15, 0x68, 0x79, 0x70, 0x65, 0x72, 0x68, 0x64, 0x72 };
 
+		_restoreDTR = false;
+
 		if (serialPortInfo.productIdentifier() == 0xa && serialPortInfo.vendorIdentifier() == 0x2e8a)
 		{
 			Warning(_log, "Detected Rp2040 type board. HyperHDR skips the reset. State: %i, %i",
@@ -77,7 +79,7 @@ class EspTools
 		}
 		else
 		{
-			_restoreDTR = _rs232Port.isDataTerminalReady();
+			_restoreDTR = true;
 
 			// reset to defaults
 			_rs232Port.setDataTerminalReady(true);

--- a/sources/leddevice/dev_serial/EspTools.h
+++ b/sources/leddevice/dev_serial/EspTools.h
@@ -38,7 +38,7 @@ class EspTools
 		_rs232Port.write((char*)comBuffer, sizeof(comBuffer));
 	}
 
-	static void initializeEsp(QSerialPort& _rs232Port, QSerialPortInfo& serialPortInfo, Logger*& _log)
+	static void initializeEsp(QSerialPort& _rs232Port, QSerialPortInfo& serialPortInfo, Logger*& _log, bool &_restoreDTR)
 	{
 		uint8_t comBuffer[] = { 0x41, 0x77, 0x41, 0x2a, 0xa2, 0x15, 0x68, 0x79, 0x70, 0x65, 0x72, 0x68, 0x64, 0x72 };
 
@@ -77,6 +77,8 @@ class EspTools
 		}
 		else
 		{
+			_restoreDTR = _rs232Port.isDataTerminalReady();
+
 			// reset to defaults
 			_rs232Port.setDataTerminalReady(true);
 			_rs232Port.setRequestToSend(false);

--- a/sources/leddevice/dev_serial/ProviderRs232.cpp
+++ b/sources/leddevice/dev_serial/ProviderRs232.cpp
@@ -133,7 +133,10 @@ void ProviderRs232::waitForExitStats(bool force)
 			disconnect(&_rs232Port, &QSerialPort::readyRead, nullptr, nullptr);
 
 			if (_restoreDTR)
+			{
 				_rs232Port.setDataTerminalReady(true);
+				_restoreDTR = false;
+			}
 
 			_rs232Port.close();
 		}

--- a/sources/leddevice/dev_serial/ProviderRs232.cpp
+++ b/sources/leddevice/dev_serial/ProviderRs232.cpp
@@ -27,6 +27,7 @@ ProviderRs232::ProviderRs232(const QJsonObject& deviceConfig)
 	, _delayAfterConnect_ms(0)
 	, _frameDropCounter(0)
 	, _espHandshake(true)
+	, _restoreDTR(false)
 {
 }
 
@@ -128,8 +129,12 @@ void ProviderRs232::waitForExitStats(bool force)
 
 		if (!_isDeviceReady && force)
 		{
-			Debug(_log, "Close UART: %s", QSTRING_CSTR(_deviceName));
+			Debug(_log, "Close UART: %s%s", QSTRING_CSTR(_deviceName), (_restoreDTR) ? " (restore DTR)": "");
 			disconnect(&_rs232Port, &QSerialPort::readyRead, nullptr, nullptr);
+
+			if (_restoreDTR)
+				_rs232Port.setDataTerminalReady(true);
+
 			_rs232Port.close();
 		}
 	}
@@ -238,7 +243,7 @@ bool ProviderRs232::tryOpen(int delayAfterConnect_ms)
 			{
 				disconnect(&_rs232Port, &QSerialPort::readyRead, nullptr, nullptr);
 
-				EspTools::initializeEsp(_rs232Port, serialPortInfo, _log);
+				EspTools::initializeEsp(_rs232Port, serialPortInfo, _log, _restoreDTR);
 			}
 		}
 		else

--- a/sources/leddevice/dev_serial/ProviderRs232.h
+++ b/sources/leddevice/dev_serial/ProviderRs232.h
@@ -119,6 +119,8 @@ private:
 	int _frameDropCounter;
 
 	bool _espHandshake;
+
+	bool _restoreDTR;
 };
 
 #endif // PROVIDERRS232_H


### PR DESCRIPTION
 Along with https://github.com/awawa-dev/HyperSerialEsp8266/pull/31 resolves #601 . Unfortunately QSerialPort:settingsRestoredOnClose is depreciated and removed from QT.
 Only Windows build was affected.