### PR TITLE
Colorized logs

### DIFF
--- a/include/utils/Logger.h
+++ b/include/utils/Logger.h
@@ -100,7 +100,7 @@ private:
 	static QMap<QString, Logger*> _loggerMap;
 	static QAtomicInteger<int>    GLOBAL_MIN_LOG_LEVEL;
 	static QString                _lastError;
-
+	static bool                   _hasConsole;
 	const QString                _name;
 	const QString                _appname;
 	const bool                   _syslogEnabled;

--- a/sources/hyperhdr/main.cpp
+++ b/sources/hyperhdr/main.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <exception>
+#include <iostream>
 
 #include <QCoreApplication>
 #include <QApplication>
@@ -150,10 +151,6 @@ int main(int argc, char** argv)
 {
 	QStringList params;
 
-	// initialize main logger and set global log level
-	Logger* log = Logger::getInstance("MAIN");
-	Logger::setLogLevel(Logger::INFO);
-
 	// check if we are running already an instance
 	// TODO Allow one session per user
 #ifdef _WIN32
@@ -216,8 +213,8 @@ int main(int argc, char** argv)
 	{
 		if (getProcessIdsByProcessName(processName).size() > 1)
 		{
-			Error(log, "The HyperHdr Daemon is already running, abort start");
-			return 0;
+			std::cerr << "The HyperHDR Daemon is already running, abort start";
+			return 1;
 		}
 	}
 	else
@@ -234,6 +231,10 @@ int main(int argc, char** argv)
 		CreateConsole();
 	}
 #endif
+
+	// initialize main logger and set global log level
+	Logger* log = Logger::getInstance("MAIN");
+	Logger::setLogLevel(Logger::INFO);
 
 	int logLevelCheck = 0;
 	if (parser.isSet(silentOption))


### PR DESCRIPTION
Let's have colorful logs when HyperHDR is run on the console. Just like HyperHDR logs in the webpage are colorful.
This makes it much easier to spot errors and warnings (and they are more pleasant and readable).
Works on Linux (console terminal) and Windows (hyperhdr.exe with -c parameter).

![obraz](https://github.com/awawa-dev/HyperHDR/assets/69086569/5c0d8bf1-6bbd-4df8-8618-3a2f0b3f3ad8)

