### PR TITLE
Upgrade Fedora 38 to 39, Ubuntu 23.04 to 23.10

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -57,8 +57,8 @@ jobs:
             dockerName: Arch Linux (x86_64)
             platform: linux
           - dockerImage: x86_64
-            linuxVersion: Fedora_38
-            dockerName: Fedora 38 (x86_64)
+            linuxVersion: Fedora_39
+            dockerName: Fedora 39 (x86_64)
             platform: linux
     steps:
       # checkout

--- a/.github/workflows/upload-to-github-pages.yml
+++ b/.github/workflows/upload-to-github-pages.yml
@@ -48,17 +48,17 @@ jobs:
             platform: linux
             niceName: Ubuntu 22.04 LTS
           - dockerImage: x86_64
-            linuxVersion: lunar
-            dockerName: Ubuntu 23.04 (x86_64)
+            linuxVersion: mantic
+            dockerName: Ubuntu 23.10 (x86_64)
             arch: amd64
             platform: linux
-            niceName: Ubuntu 23.04
+            niceName: Ubuntu 23.10
           - dockerImage: x86_64
-            linuxVersion: Fedora_38
-            dockerName: Fedora 38 (x86_64)
+            linuxVersion: Fedora_39
+            dockerName: Fedora 39 (x86_64)
             arch: amd64
             platform: linux
-            niceName: Fedora 38
+            niceName: Fedora 39
 
     steps:
       # checkout


### PR DESCRIPTION
Upgrade:
Fedora 38 to 39 (for release build and Github Action)
Ubuntu 23.04 to 23.10 (for release build)