### PR TITLE
Workaround for Github macOS runner bug

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -155,7 +155,7 @@ jobs:
       # Install deps
       - name: Install deps
         shell: bash
-        run: brew update && brew install qt@${{ env.QT_VERSION }} xz ccache zstd webp
+        run: brew remove azure-cli && brew update && brew install qt@${{ env.QT_VERSION }} xz ccache zstd webp jpeg-turbo
         
       # Set env
       - name: Set QT5 env


### PR DESCRIPTION
Installing brew packages causing Github macOS runner azure-cli to trigger install Python that fails. Both packages are not used by HyperHDR.