### PR TITLE
Github macos-latest runner workaround

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -155,7 +155,7 @@ jobs:
       # Install deps
       - name: Install deps
         shell: bash
-        run: brew remove azure-cli && brew update && brew install qt@${{ env.QT_VERSION }} xz ccache zstd webp jpeg-turbo
+        run: brew install qt@${{ env.QT_VERSION }} xz ccache zstd webp jpeg-turbo || true
         
       # Set env
       - name: Set QT5 env


### PR DESCRIPTION
Another workaround for Github `macos-latest` runner image that currently is in a messy state causing the build to randomly fail
https://github.com/actions/runner-images/issues/8838
https://github.com/actions/runner-images/issues/8529
https://github.com/actions/runner-images/issues/8642
and many others...