### PR TITLE
fix pipewire portal by removing blocks parameter

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -2,6 +2,7 @@ name: HyperHDR CI Build
 
 on:
   push:
+  pull_request:
 
 env:
     USE_CACHE: "1"

--- a/sources/grabber/pipewire/PipewireHandler.cpp
+++ b/sources/grabber/pipewire/PipewireHandler.cpp
@@ -219,14 +219,15 @@ void PipewireHandler::closeSession()
 #ifdef ENABLE_PIPEWIRE_EGL
 	if (contextEgl != EGL_NO_CONTEXT)
 	{
-		eglDestroyContext(displayEgl, contextEgl);
+		auto res = eglDestroyContext(displayEgl, contextEgl);
+		std::cout << "PipewireEGL: destroying EGL context => " << res << std::endl;
 		contextEgl = EGL_NO_CONTEXT;
 	}
 
 	if (displayEgl != EGL_NO_DISPLAY)
 	{
-		printf("PipewireEGL: terminate the display\n");
-		eglTerminate(displayEgl);
+		auto res = eglTerminate(displayEgl);
+		std::cout << "PipewireEGL: terminate the display => " << res << std::endl;		
 		displayEgl = EGL_NO_DISPLAY;
 	}
 
@@ -590,7 +591,7 @@ void PipewireHandler::onStateChanged(pw_stream_state old, pw_stream_state state,
 
 void PipewireHandler::onParamsChanged(uint32_t id, const struct spa_pod* param)
 {
-	struct spa_video_info format;
+	struct spa_video_info format {};
 
 	std::cout << "Pipewire: got new video format selected" << std::endl;
 

--- a/sources/grabber/pipewire/PipewireHandler.cpp
+++ b/sources/grabber/pipewire/PipewireHandler.cpp
@@ -644,7 +644,9 @@ void PipewireHandler::onParamsChanged(uint32_t id, const struct spa_pod* param)
 	updatedParams[0] = (spa_pod*)(spa_pod*)spa_pod_builder_add_object(&updateBufferBuilder,
 					SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
 					SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(2, 2, 16),
+#if !PW_CHECK_VERSION(1, 0, 0)
 					SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1),
+#endif
 					SPA_PARAM_BUFFERS_size, SPA_POD_Int(size),
 					SPA_PARAM_BUFFERS_stride, SPA_POD_CHOICE_RANGE_Int(stride, stride, INT32_MAX),
 					SPA_PARAM_BUFFERS_align, SPA_POD_Int(16),


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
When this parameter is enabled than pipewire reports the following error:

**HyperHDR:**
Pipewire: updated parameters 0
Pipewire: core error reported
Pipewire: stream reports error 'error alloc buffers: Invalid argument' Pipewire: core reports error 'error alloc buffers: Invalid argument'

**Pipewire:**
pipewire[1850759]: pw.context: params Spa:Enum:ParamId:Buffers: 1:0 Invalid argument (input param) pipewire[1850759]: pw.context: Object: size 168, type Spa:Pod:Object:Param:Buffers (262148), id Spa:Enum:ParamId:Buffers (5)
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:BlockInfo:size (3), flags 00000000
pipewire[1850759]: pw.context:     Int 33177600
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:buffers (1), flags 00000000
pipewire[1850759]: pw.context:     Choice: type Spa:Enum:Choice:Range, flags 00000000 28 4
pipewire[1850759]: pw.context:       Int 16
pipewire[1850759]: pw.context:       Int 2
pipewire[1850759]: pw.context:       Int 16
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:BlockInfo:stride (4), flags 00000000
pipewire[1850759]: pw.context:     Int 15360
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:BlockInfo:dataType (6), flags 00000000
pipewire[1850759]: pw.context:     Choice: type Spa:Enum:Choice:Flags, flags 00000000 20 4
pipewire[1850759]: pw.context:       Int 12
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:blocks (2), flags 00000000
pipewire[1850759]: pw.context:     Int 3
pipewire[1850759]: pw.context: params Spa:Enum:ParamId:Buffers: 0:0 Invalid argument (output param)
pipewire[1850759]: pw.context: Object: size 216, type Spa:Pod:Object:Param:Buffers (262148), id Spa:Enum:ParamId:Buffers (5)
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:buffers (1), flags 00000000
pipewire[1850759]: pw.context:     Choice: type Spa:Enum:Choice:Range, flags 00000000 28 4
pipewire[1850759]: pw.context:       Int 2
pipewire[1850759]: pw.context:       Int 2
pipewire[1850759]: pw.context:       Int 16
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:blocks (2), flags 00000000
pipewire[1850759]: pw.context:     Int 1
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:BlockInfo:size (3), flags 00000000
pipewire[1850759]: pw.context:     Int 33177600
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:BlockInfo:stride (4), flags 00000000
pipewire[1850759]: pw.context:     Choice: type Spa:Enum:Choice:Range, flags 00000000 28 4
pipewire[1850759]: pw.context:       Int 15360
pipewire[1850759]: pw.context:       Int 15360
pipewire[1850759]: pw.context:       Int 2147483647
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:BlockInfo:align (5), flags 00000000
pipewire[1850759]: pw.context:     Int 16
pipewire[1850759]: pw.context:   Prop: key Spa:Pod:Object:Param:Buffers:BlockInfo:dataType (6), flags 00000000
pipewire[1850759]: pw.context:     Choice: type Spa:Enum:Choice:Flags, flags 00000000 20 4
pipewire[1850759]: pw.context:       Int 14
pipewire[1850759]: pw.link: (103.0.0 -> 79.0.0) allocating -> error (error alloc buffers: Invalid argument) (ready-ready)

This happens with pipewire 1.0.0 and pipewire master.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No
- [x] Don't know

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
