### PR TITLE
Force HyperSerial detection

### DIFF
--- a/sources/leddevice/dev_serial/EspTools.h
+++ b/sources/leddevice/dev_serial/EspTools.h
@@ -38,7 +38,7 @@ public:
 		_rs232Port.write((char*)comBuffer, sizeof(comBuffer));
 	}
 
-	static void initializeEsp(QSerialPort& _rs232Port, QSerialPortInfo& serialPortInfo, Logger*& _log)
+	static void initializeEsp(QSerialPort& _rs232Port, QSerialPortInfo& serialPortInfo, Logger*& _log, bool _forceSerialDetection)
 	{
 		uint8_t comBuffer[] = { 0x41, 0x77, 0x41, 0x2a, 0xa2, 0x15, 0x68, 0x79, 0x70, 0x65, 0x72, 0x68, 0x64, 0x72 };
 
@@ -67,6 +67,17 @@ public:
 		else if (serialPortInfo.productIdentifier() == 0x3483 && serialPortInfo.vendorIdentifier() == 0x1106)
 		{
 			Warning(_log, "Enabling the Rpi4 udev bug workaround. The serial device is incorrectly identified by the OS and HyperHDR skips the reset. State: %i, %i",
+				_rs232Port.isDataTerminalReady(), _rs232Port.isRequestToSend());
+
+			_rs232Port.write((char*)comBuffer, sizeof(comBuffer));
+
+			_rs232Port.setDataTerminalReady(true);
+			_rs232Port.setRequestToSend(true);
+			_rs232Port.setRequestToSend(false);
+		}
+		else if (!serialPortInfo.hasProductIdentifier() && !serialPortInfo.hasVendorIdentifier() && _forceSerialDetection)
+		{
+			Warning(_log, "Force ESP/Pico detection override enabled. HyperHDR skips the reset. State: %i, %i",
 				_rs232Port.isDataTerminalReady(), _rs232Port.isRequestToSend());
 
 			_rs232Port.write((char*)comBuffer, sizeof(comBuffer));

--- a/sources/leddevice/dev_serial/ProviderRs232.cpp
+++ b/sources/leddevice/dev_serial/ProviderRs232.cpp
@@ -32,6 +32,7 @@ ProviderRs232::ProviderRs232(const QJsonObject& deviceConfig)
 	, _delayAfterConnect_ms(0)
 	, _frameDropCounter(0)
 	, _espHandshake(true)
+	, _forceSerialDetection(true)
 {
 }
 
@@ -58,11 +59,13 @@ bool ProviderRs232::init(const QJsonObject& deviceConfig)
 		_delayAfterConnect_ms = deviceConfig["delayAfterConnect"].toInt(0);
 		_espHandshake = deviceConfig["espHandshake"].toBool(false);
 		_maxRetry = _devConfig["maxRetry"].toInt(60);
+		_forceSerialDetection = deviceConfig["forceSerialDetection"].toBool(false);
 
 		Debug(_log, "Device name   : %s", QSTRING_CSTR(_deviceName));
 		Debug(_log, "Auto selection: %d", _isAutoDeviceName);
 		Debug(_log, "Baud rate     : %d", _baudRate_Hz);
 		Debug(_log, "ESP handshake : %s", (_espHandshake) ? "ON" : "OFF");
+		Debug(_log, "Force ESP/Pico Detection : %s", (_forceSerialDetection) ? "ON" : "OFF");
 		Debug(_log, "Delayed open  : %d", _delayAfterConnect_ms);
 		Debug(_log, "Retry limit   : %d", _maxRetry);
 
@@ -246,7 +249,7 @@ bool ProviderRs232::tryOpen(int delayAfterConnect_ms)
 			{
 				disconnect(&_rs232Port, &QSerialPort::readyRead, nullptr, nullptr);
 
-				EspTools::initializeEsp(_rs232Port, serialPortInfo, _log);
+				EspTools::initializeEsp(_rs232Port, serialPortInfo, _log, _forceSerialDetection);
 			}
 		}
 		else

--- a/sources/leddevice/dev_serial/ProviderRs232.h
+++ b/sources/leddevice/dev_serial/ProviderRs232.h
@@ -119,6 +119,8 @@ private:
 	int _frameDropCounter;
 
 	bool _espHandshake;
+
+	bool _forceSerialDetection;
 };
 
 #endif // PROVIDERRS232_H

--- a/sources/leddevice/schemas/schema-adalight.json
+++ b/sources/leddevice/schemas/schema-adalight.json
@@ -35,6 +35,21 @@
 			},
 			"propertyOrder" : 4
 		},
+		"forceSerialDetection" :
+		{
+
+			"type" : "boolean",
+			"format": "checkbox",
+			"title" : "edt_dev_spec_forceSerialDetection",		
+			"default" : false,
+			"required" : true,
+			"options": {
+				"dependencies": {
+					"awa_mode": true
+				}
+			},
+			"propertyOrder" : 5
+		},
 		"white_channel_calibration": {
 			"type": "boolean",
 			"format": "checkbox",
@@ -46,7 +61,7 @@
 					"awa_mode": true
 				}
 			},
-			"propertyOrder" : 5
+			"propertyOrder" : 6
 		},
 		"white_channel_limit": {
 			"type": "number",
@@ -63,7 +78,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 6
+			"propertyOrder" : 7
 		},
 		"white_channel_red": {
 			"type": "integer",
@@ -79,7 +94,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 7
+			"propertyOrder" : 8
 		},
 		"white_channel_green": {
 			"type": "integer",
@@ -95,7 +110,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 8
+			"propertyOrder" : 9
 		},
 		"white_channel_blue": {
 			"type": "integer",
@@ -111,7 +126,7 @@
 					"white_channel_calibration": true
 				}
 			},
-			"propertyOrder" : 9
+			"propertyOrder" : 10
 		},
 		"delayAfterConnect": {
 			"type": "integer",
@@ -124,7 +139,7 @@
 					"awa_mode": false
 				}
 			},
-			"propertyOrder" : 10
+			"propertyOrder" : 11
 		},
 		"lightberry_apa102_mode": {
 			"type": "boolean",
@@ -137,7 +152,7 @@
 					"awa_mode": false
 				}
 			},
-			"propertyOrder" : 11
+			"propertyOrder" : 12
 		},
 		"maxRetry":
 		{
@@ -149,7 +164,7 @@
 			"maximum" : 120,
 			"default" : 0,
 			"required" : true,
-			"propertyOrder" : 12
+			"propertyOrder" : 13
 		}
 	},
 	"additionalProperties": true

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -1199,6 +1199,7 @@
   "edt_serial_espHandshake" : "Esp8266/ESP32/Rp2040 handshake (<a href='https://github.com/awawa-dev/HyperHDR/wiki/HyperSerial' style='color:red'>info</a>)",
   "edt_rpi_ws281x_driver" : "This driver is intended for advanced users and is <b>not recommended or supported</b> by the HyperHDR team. Please read the project FAQ section for reasons and don't ask us for help if you try to use it because it <b>revokes any support for your entire HyperHDR configuration</b>. Choose a better solution like HyperSerialEsp8266/HyperSerialESP32 (<a href='https://github.com/awawa-dev/HyperHDR/wiki/HyperSerial' style='color:red'>about</a>) or HyperSPI (<a href='https://github.com/awawa-dev/HyperSPI' style='color:red'>about</a>).",
   "edt_dev_spec_awa_mode_title": "High speed serial AWA protocol with data integrity check (<a href='https://github.com/awawa-dev/HyperHDR/wiki/HyperSerial' style='color:red'>info</a>)",
+  "edt_dev_spec_forceSerialDetection": "Force ttyACM detection (for webOS: if serial port info returns empty)",
   "led_editor_context_identify": "Identify",
   "main_menu_grabber_lut" : "Download LUT",
   "main_menu_grabber_lut_title" : "Custom LUT for USB grabber",


### PR DESCRIPTION
Ignore ProductId/VendorId  of the serial port device and force initialization HyperSerial driver. Thanks @alex-013