### PR TITLE
New features: disable LEDs/components on startup, stop processing when user has locked the system

### DIFF
--- a/include/base/ComponentController.h
+++ b/include/base/ComponentController.h
@@ -15,7 +15,7 @@ class ComponentController : public QObject
 	Q_OBJECT
 
 public:
-    ComponentController(HyperHdrInstance* hyperhdr);
+    ComponentController(HyperHdrInstance* hyperhdr, bool disableOnStartup);
     virtual ~ComponentController();
 
 	int isComponentEnabled(hyperhdr::Components comp) const;
@@ -35,4 +35,5 @@ private:
 	Logger* _log;
 	std::map<hyperhdr::Components, bool> _componentStates;
 	std::map<hyperhdr::Components, bool> _prevComponentStates;
+	bool _disableOnStartup;
 };

--- a/include/base/HyperHdrInstance.h
+++ b/include/base/HyperHdrInstance.h
@@ -51,7 +51,7 @@ class HyperHdrInstance : public QObject
 	Q_OBJECT
 
 public:
-	HyperHdrInstance(quint8 instance, bool readonlyMode, QString name);
+	HyperHdrInstance(quint8 instance, bool readonlyMode, bool disableOnstartup, QString name);
 	~HyperHdrInstance();
 	
 	quint8 getInstanceIndex() const { return _instIndex; }
@@ -158,6 +158,7 @@ private:
 	QString					_name;
 
 	bool					_readOnlyMode;
+	bool					_disableOnStartup;
 
 	static std::atomic<bool>	_signalTerminate;
 	static std::atomic<int>		_totalRunningCount;

--- a/include/base/HyperHdrManager.h
+++ b/include/base/HyperHdrManager.h
@@ -54,7 +54,7 @@ public slots:
 
 	QVector<QVariantMap> getInstanceData() const;
 
-	bool startInstance(quint8 inst, QObject* caller = nullptr, int tan = 0);
+	bool startInstance(quint8 inst, QObject* caller = nullptr, int tan = 0, bool disableOnStartup = false);
 
 	bool stopInstance(quint8 inst);
 
@@ -97,7 +97,7 @@ private:
 
 	HyperHdrManager(const QString& rootPath, bool readonlyMode);
 
-	void startAll();
+	void startAll(bool disableOnStartup);
 
 	void stopAllonExit();
 

--- a/include/leddevice/LedDevice.h
+++ b/include/leddevice/LedDevice.h
@@ -70,6 +70,7 @@ public slots:
 	void blinking(QJsonObject params);
 	void smoothingRestarted(int newSmoothingInterval);
 	int hasLedClock();
+	void pauseRetryTimer(bool mode);
 
 signals:
 	void SignalEnableStateChanged(bool newState);
@@ -155,4 +156,5 @@ private:
 	int _blinkIndex;
 	qint64 _blinkTime;
 	int _instanceIndex;
+	int _pauseRetryTimer;
 };

--- a/include/leddevice/LedDeviceWrapper.h
+++ b/include/leddevice/LedDeviceWrapper.h
@@ -22,7 +22,7 @@ public:
 	explicit LedDeviceWrapper(HyperHdrInstance* ownerInstance);
 	virtual ~LedDeviceWrapper();
 
-	void createLedDevice(QJsonObject config, int smoothingInterval);
+	void createLedDevice(QJsonObject config, int smoothingInterval, bool disableOnStartup);
 	static QJsonObject getLedDeviceSchemas();
 	static int addToDeviceMap(QString name, LedDeviceCreateFuncType funcPtr);
 	static const LedDeviceRegistry& getDeviceMap();

--- a/sources/base/HyperHdrInstance.cpp
+++ b/sources/base/HyperHdrInstance.cpp
@@ -684,9 +684,15 @@ void HyperHdrInstance::handlePriorityChangedLedDevice(const quint8& priority)
 		if (previousPriority == Muxer::LOWEST_PRIORITY)
 		{
 			Info(_log, "New source available -> switch LED-Device on");
-
-			emit SignalRequestComponent(hyperhdr::COMP_LEDDEVICE, true);
-			emit GlobalSignals::getInstance()->SignalPerformanceStateChanged(true, hyperhdr::PerformanceReportType::INSTANCE, getInstanceIndex(), _name);
+			if (!isComponentEnabled(hyperhdr::Components::COMP_ALL))
+			{
+				Warning(_log, "Components are disabled: ignoring switching LED-Device on");
+			}
+			else
+			{
+				emit SignalRequestComponent(hyperhdr::COMP_LEDDEVICE, true);
+				emit GlobalSignals::getInstance()->SignalPerformanceStateChanged(true, hyperhdr::PerformanceReportType::INSTANCE, getInstanceIndex(), _name);
+			}
 		}
 	}
 }

--- a/sources/base/HyperHdrInstance.cpp
+++ b/sources/base/HyperHdrInstance.cpp
@@ -67,7 +67,7 @@
 std::atomic<bool> HyperHdrInstance::_signalTerminate(false);
 std::atomic<int>  HyperHdrInstance::_totalRunningCount(0);
 
-HyperHdrInstance::HyperHdrInstance(quint8 instance, bool readonlyMode, QString name)
+HyperHdrInstance::HyperHdrInstance(quint8 instance, bool readonlyMode, bool disableOnStartup, QString name)
 	: QObject()
 	, _instIndex(instance)
 	, _bootEffect(QTime::currentTime().addSecs(5))
@@ -90,6 +90,7 @@ HyperHdrInstance::HyperHdrInstance(quint8 instance, bool readonlyMode, QString n
 	, _currentLedColors()
 	, _name((name.isEmpty()) ? QString("INSTANCE%1").arg(instance) : name)
 	, _readOnlyMode(readonlyMode)
+	, _disableOnStartup(disableOnStartup)
 {
 	_totalRunningCount++;
 }
@@ -142,7 +143,7 @@ void HyperHdrInstance::start()
 	Info(_log, "Starting the instance");	
 
 	_instanceConfig = std::unique_ptr<InstanceConfig>(new InstanceConfig(false, _instIndex, this, _readOnlyMode));
-	_componentController = std::unique_ptr<ComponentController>(new ComponentController(this));
+	_componentController = std::unique_ptr<ComponentController>(new ComponentController(this, _disableOnStartup));
 	connect(_componentController.get(), &ComponentController::SignalComponentStateChanged, this, &HyperHdrInstance::SignalComponentStateChanged);
 	_ledString = LedString::createLedString(getSetting(settings::type::LEDS).array(), LedString::createColorOrder(getSetting(settings::type::DEVICE).object()));
 	_muxer = std::unique_ptr<Muxer>(new Muxer(_instIndex, static_cast<int>(_ledString.leds().size()), this));
@@ -184,7 +185,7 @@ void HyperHdrInstance::start()
 
 	_ledDeviceWrapper = std::unique_ptr<LedDeviceWrapper>(new LedDeviceWrapper(this));
 	connect(this, &HyperHdrInstance::SignalRequestComponent, _ledDeviceWrapper.get(), &LedDeviceWrapper::handleComponentState);
-	_ledDeviceWrapper->createLedDevice(ledDevice, _smoothing->GetSuggestedInterval());
+	_ledDeviceWrapper->createLedDevice(ledDevice, _smoothing->GetSuggestedInterval(), _disableOnStartup);
 
 	// create the effect engine; needs to be initialized after smoothing!
 	_effectEngine = std::unique_ptr<EffectEngine>(new EffectEngine(this));
@@ -221,6 +222,12 @@ void HyperHdrInstance::start()
 
 	// instance initiated, enter thread event loop
 	emit SignalInstanceJustStarted();
+
+	if (_disableOnStartup)
+	{
+		_componentController->setNewComponentState(hyperhdr::COMP_ALL, false);
+		Warning(_log, "The user has disabled LEDs auto-start in the configuration (interface: 'General' tab)");
+	}
 
 	// exit
 	Info(_log, "The instance is running");
@@ -295,9 +302,7 @@ void HyperHdrInstance::handleSettingsUpdate(settings::type type, const QJsonDocu
 
 		// do always reinit until the led devices can handle dynamic changes
 		dev["currentLedCount"] = _hwLedCount; // Inject led count info
-		_ledDeviceWrapper->createLedDevice(dev, _smoothing->GetSuggestedInterval());
-
-		// TODO: Check, if framegrabber frequency is lower than latchtime..., if yes, stop
+		_ledDeviceWrapper->createLedDevice(dev, _smoothing->GetSuggestedInterval(), false);		
 	}
 	else if (type == settings::type::BGEFFECT || type == settings::type::FGEFFECT)
 	{

--- a/sources/base/HyperHdrManager.cpp
+++ b/sources/base/HyperHdrManager.cpp
@@ -102,7 +102,7 @@ bool HyperHdrManager::areInstancesReady()
 	return (--_fireStarter == 0);
 }
 
-void HyperHdrManager::startAll()
+void HyperHdrManager::startAll(bool disableOnStartup)
 {
 	auto instanceList = _instanceTable->getAllInstances(true);
 
@@ -110,7 +110,7 @@ void HyperHdrManager::startAll()
 
 	for (const auto& entry : instanceList)
 	{
-		startInstance(entry["instance"].toInt());
+		startInstance(entry["instance"].toInt(), nullptr, 0, disableOnStartup);
 	}
 }
 
@@ -179,7 +179,7 @@ void HyperHdrManager::hibernate(bool wakeUp)
 	}
 }
 
-bool HyperHdrManager::startInstance(quint8 inst, QObject* caller, int tan)
+bool HyperHdrManager::startInstance(quint8 inst, QObject* caller, int tan, bool disableOnStartup)
 {
 	if (_instanceTable->instanceExist(inst))
 	{
@@ -191,6 +191,7 @@ bool HyperHdrManager::startInstance(quint8 inst, QObject* caller, int tan)
 			auto hyperhdr = std::shared_ptr<HyperHdrInstance>(
 				new HyperHdrInstance(inst,
 					_readonlyMode,
+					disableOnStartup,
 					_instanceTable->getNamebyIndex(inst)),
 				[](HyperHdrInstance* oldInstance) {
 					THREAD_REMOVER(QString("HyperHDR instance at index = %1").arg(oldInstance->getInstanceIndex()),

--- a/sources/base/schema/schema-general.json
+++ b/sources/base/schema/schema-general.json
@@ -41,6 +41,15 @@
 			"default" : false,
 			"required" : true,
 			"propertyOrder" : 5
+		},
+		"disableLedsStartup" :
+		{
+			"type" : "boolean",
+			"format": "checkbox",
+			"title" : "edt_conf_gen_disableLedsStartup_title",
+			"default" : false,
+			"required" : true,
+			"propertyOrder" : 6
 		}
 
 	},

--- a/sources/base/schema/schema-general.json
+++ b/sources/base/schema/schema-general.json
@@ -32,6 +32,15 @@
 				"hidden":true
 			},
 			"propertyOrder" : 4
+		},
+		"disableOnLocked" :
+		{
+			"type" : "boolean",
+			"format": "checkbox",
+			"title" : "edt_conf_gen_disableOnLocked_title",
+			"default" : false,
+			"required" : true,
+			"propertyOrder" : 5
 		}
 
 	},

--- a/sources/grabber/DX/DxGrabber.cpp
+++ b/sources/grabber/DX/DxGrabber.cpp
@@ -313,6 +313,8 @@ void DxGrabber::stop()
 		_timer->stop();
 		Info(_log, "Stopped");
 	}
+
+	_retryTimer->stop();
 }
 
 bool DxGrabber::initDirectX(QString selectedDeviceName)

--- a/sources/hyperhdr/HyperHdrDaemon.cpp
+++ b/sources/hyperhdr/HyperHdrDaemon.cpp
@@ -177,7 +177,11 @@ HyperHdrDaemon::HyperHdrDaemon(const QString& rootPath, QApplication* parent, bo
 
 	// power management
 	#if defined(HAVE_POWER_MANAGEMENT)
-		_suspendHandler = std::unique_ptr<SuspendHandler>(new SuspendHandler());
+		auto genSet = getSetting(settings::type::GENERAL);
+		const QJsonObject& genConfig = genSet.object();
+		bool lockedEnable = genConfig["disableOnLocked"].toBool(false);
+
+		_suspendHandler = std::unique_ptr<SuspendHandler>(new SuspendHandler(lockedEnable));
 		connect(_suspendHandler.get(), &SuspendHandler::SignalHibernate, _instanceManager.get(), &HyperHdrManager::hibernate);
 
 		#ifdef _WIN32

--- a/sources/hyperhdr/HyperHdrDaemon.cpp
+++ b/sources/hyperhdr/HyperHdrDaemon.cpp
@@ -82,6 +82,7 @@ HyperHdrDaemon::HyperHdrDaemon(const QString& rootPath, QApplication* parent, bo
 	, _rootPath(rootPath)
 	, _params(params)
 	, _isGuiApp(isGuiApp)
+	, _disableOnStart(false)
 {
 
 	// Register metas for thread queued connection
@@ -166,7 +167,9 @@ HyperHdrDaemon::HyperHdrDaemon(const QString& rootPath, QApplication* parent, bo
 	// spawn all Hyperhdr instances (non blocking)
 	settingsChangedHandler(settings::type::VIDEOGRABBER, getSetting(settings::type::VIDEOGRABBER));
 	settingsChangedHandler(settings::type::SYSTEMGRABBER, getSetting(settings::type::SYSTEMGRABBER));
-	_instanceManager->startAll();
+	QJsonObject genConfig = getSetting(settings::type::GENERAL).object();	
+	_disableOnStart = genConfig["disableLedsStartup"].toBool(false);
+	_instanceManager->startAll(_disableOnStart);
 
 	//Cleaning up Hyperhdr before quit
 	connect(parent, &QCoreApplication::aboutToQuit, this, &HyperHdrDaemon::freeObjects);
@@ -177,8 +180,6 @@ HyperHdrDaemon::HyperHdrDaemon(const QString& rootPath, QApplication* parent, bo
 
 	// power management
 	#if defined(HAVE_POWER_MANAGEMENT)
-		auto genSet = getSetting(settings::type::GENERAL);
-		const QJsonObject& genConfig = genSet.object();
 		bool lockedEnable = genConfig["disableOnLocked"].toBool(false);
 
 		_suspendHandler = std::unique_ptr<SuspendHandler>(new SuspendHandler(lockedEnable));
@@ -227,6 +228,12 @@ void HyperHdrDaemon::instanceStateChangedHandler(InstanceState state, quint8 ins
 			{
 				_networkThread->start();
 			}
+
+			if (_disableOnStart)
+			{
+				Warning(_log, "The user has disabled LEDs auto-start in the configuration (interface: 'General' tab)");
+				_instanceManager->toggleStateAllInstances(false);				
+			}			
 		}
 	}
 }

--- a/sources/hyperhdr/HyperHdrDaemon.h
+++ b/sources/hyperhdr/HyperHdrDaemon.h
@@ -170,5 +170,6 @@ private:
 	bool				_readonlyMode;
 	QStringList			_params;
 	bool				_isGuiApp;
+	bool				_disableOnStart;
 };
 

--- a/sources/hyperhdr/SuspendHandlerLinux.cpp
+++ b/sources/hyperhdr/SuspendHandlerLinux.cpp
@@ -46,7 +46,7 @@ namespace {
 	const QString UPOWER_INTER = QStringLiteral("org.freedesktop.login1.Manager");
 }
 
-SuspendHandler::SuspendHandler()
+SuspendHandler::SuspendHandler(bool sessionLocker)
 {
 	QDBusConnection bus = QDBusConnection::systemBus();
 

--- a/sources/hyperhdr/SuspendHandlerLinux.h
+++ b/sources/hyperhdr/SuspendHandlerLinux.h
@@ -37,7 +37,7 @@ signals:
 	void SignalHibernate(bool wakeUp);
 
 public:
-	SuspendHandler();
+	SuspendHandler(bool sessionLocker = false);
 	~SuspendHandler();
 
 public slots:

--- a/sources/hyperhdr/SuspendHandlerMacOS.h
+++ b/sources/hyperhdr/SuspendHandlerMacOS.h
@@ -37,6 +37,6 @@ signals:
 	void SignalHibernate(bool wakeUp);
 
 public:
-	SuspendHandler();
+	SuspendHandler(bool sessionLocker = false);
 	~SuspendHandler();
 };

--- a/sources/hyperhdr/SuspendHandlerMacOS.mm
+++ b/sources/hyperhdr/SuspendHandlerMacOS.mm
@@ -89,7 +89,7 @@ namespace {
 
 @end
 
-SuspendHandler::SuspendHandler()
+SuspendHandler::SuspendHandler(bool sessionLocker)
 {
 	_macSuspendHandlerInstance = [MacSuspendHandler new];
 	_suspendHandler = this;

--- a/sources/hyperhdr/SuspendHandlerWindows.h
+++ b/sources/hyperhdr/SuspendHandlerWindows.h
@@ -40,12 +40,13 @@ class SuspendHandler : public QObject, public QAbstractNativeEventFilter {
 
 	QWidget			_widget;
 	HPOWERNOTIFY	_notifyHandle;
+	bool			_sessionLocker;
 
 signals:
 	void SignalHibernate(bool wakeUp);
 
 public:
-	SuspendHandler();
+	SuspendHandler(bool sessionLocker = false);
 	~SuspendHandler();
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	virtual bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) Q_DECL_OVERRIDE;

--- a/sources/leddevice/LedDeviceWrapper.cpp
+++ b/sources/leddevice/LedDeviceWrapper.cpp
@@ -44,7 +44,7 @@ LedDeviceWrapper::~LedDeviceWrapper()
 	_ledDevice.reset();
 }
 
-void LedDeviceWrapper::createLedDevice(QJsonObject config, int smoothingInterval)
+void LedDeviceWrapper::createLedDevice(QJsonObject config, int smoothingInterval, bool disableOnStartup)
 {
 	_ledDevice.reset();
 
@@ -63,7 +63,8 @@ void LedDeviceWrapper::createLedDevice(QJsonObject config, int smoothingInterval
 	_ledDevice->moveToThread(thread);
 
 	// setup thread management
-	connect(thread, &QThread::started, _ledDevice.get(), &LedDevice::start);
+	if (!disableOnStartup)
+		connect(thread, &QThread::started, _ledDevice.get(), &LedDevice::start);
 	connect(thread, &QThread::finished, _ledDevice.get(), &LedDevice::stop);
 	connect(_ownerInstance, &HyperHdrInstance::SignalSmoothingRestarted, _ledDevice.get(), &LedDevice::smoothingRestarted, Qt::QueuedConnection);
 	connect(_ledDevice.get(), &LedDevice::SignalEnableStateChanged, this, &LedDeviceWrapper::handleInternalEnableState, Qt::QueuedConnection);

--- a/sources/leddevice/LedDeviceWrapper.cpp
+++ b/sources/leddevice/LedDeviceWrapper.cpp
@@ -88,6 +88,11 @@ void LedDeviceWrapper::handleComponentState(hyperhdr::Components component, bool
 			QUEUE_CALL_0(_ledDevice.get(), disable);
 		}
 	}
+
+	if (component == hyperhdr::COMP_ALL)
+	{
+		QUEUE_CALL_1(_ledDevice.get(), pauseRetryTimer, bool, (!state));
+	}
 }
 
 void LedDeviceWrapper::handleInternalEnableState(bool newState)

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -1239,5 +1239,7 @@
   "edt_conf_monitor_nits_expl" : "SDR target brightness used for HDR to SDR conversion. If 0, it disables hardware color conversion while maintaining accelerated scaling.",
   "edt_append_nits" : "nits",
   "edt_conf_gen_disableOnLocked_title" : "Disable when locked",
-  "edt_conf_gen_disableOnLocked_expl" : "Turn off processing when the user has locked the system"
+  "edt_conf_gen_disableOnLocked_expl" : "Turn off processing when the user has locked the system",
+  "edt_conf_gen_disableLedsStartup_title" : "Turn off LEDs at startup",
+  "edt_conf_gen_disableLedsStartup_expl" : "Disable LEDs and all components on startup, you must re-enable them manually on the main page or via the JSON API (COMP_ALL component)"
 }

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -1237,5 +1237,7 @@
   "edt_conf_hardware_expl" : "Enable hardware acceleration, for example: pixel and vertex shaders on Windows",
   "edt_conf_monitor_nits_title" : "HDR brightness correction",
   "edt_conf_monitor_nits_expl" : "SDR target brightness used for HDR to SDR conversion. If 0, it disables hardware color conversion while maintaining accelerated scaling.",
-  "edt_append_nits" : "nits"
-} 
+  "edt_append_nits" : "nits",
+  "edt_conf_gen_disableOnLocked_title" : "Disable when locked",
+  "edt_conf_gen_disableOnLocked_expl" : "Turn off processing when the user has locked the system"
+}

--- a/www/js/general.js
+++ b/www/js/general.js
@@ -235,5 +235,15 @@ $(document).ready(function()
 		createHint("intro", $.i18n('conf_general_inst_desc'), "inst_desc_cont");
 	}
 
+	if (window.serverInfo.grabbers != null && window.serverInfo.grabbers != undefined &&
+		window.serverInfo.grabbers.active != null && window.serverInfo.grabbers.active != undefined)
+	{
+		var grabbers = window.serverInfo.grabbers.active;
+		if (grabbers.indexOf('Media Foundation') < 0)
+		{
+			conf_editor.getEditor('root.general.disableOnLocked').disable();
+		}
+	}
+
 	removeOverlay();
 });


### PR DESCRIPTION
1 If user has locked the Win system, for example using windows + L keys, HyperHDR stops processing and turns off the LEDs.
It resumes when the user unlock the system. Fixes #735

2 Added an option that cause HyperHDR not to turn on LEDs when starts up. Implements #627

![obraz](https://github.com/awawa-dev/HyperHDR/assets/69086569/27713fd2-780c-48dd-83d5-c44ca32afa63)