### PR TITLE
Enhanced HyperHDR behavior when the system is locked or the monitor is turned off

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -142,7 +142,7 @@ jobs:
           - JOB_RUNNER: macos-14
             JOB_NAME: macOS 14 (arm64/M1/M2)
             QT_VERSION: 6
-            NICE_NAME: arm64_M1
+            NICE_NAME: arm64_M1_M2
           - JOB_RUNNER: macos-13
             JOB_NAME: macOS 13 (x64)
             QT_VERSION: 5
@@ -206,7 +206,7 @@ jobs:
         if: (startsWith(github.event.ref, 'refs/tags') != true) && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-            name: Apple_macOS_@${{ matrix.NICE_NAME }}_DMG_installer
+            name: Apple_macOS_${{ matrix.NICE_NAME }}_DMG_installer
             path: build/Hyper*.dmg
 
 ######################
@@ -257,7 +257,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags') && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: release-artifact-${{ matrix.runs-on }}
+          name: release-artifact-windows
           path: build/Hyper*
           
       # Upload artifacts from commit

--- a/include/base/ComponentController.h
+++ b/include/base/ComponentController.h
@@ -27,6 +27,7 @@ signals:
 
 public slots:
 	void setNewComponentState(hyperhdr::Components comp, bool activated);
+	void turnGrabbers(bool activated);
 
 private slots:
 	void handleCompStateChangeRequest(hyperhdr::Components comps, bool activated);
@@ -35,5 +36,6 @@ private:
 	Logger* _log;
 	std::map<hyperhdr::Components, bool> _componentStates;
 	std::map<hyperhdr::Components, bool> _prevComponentStates;
+	std::map<hyperhdr::Components, bool> _prevGrabbers;
 	bool _disableOnStartup;
 };

--- a/include/base/HyperHdrInstance.h
+++ b/include/base/HyperHdrInstance.h
@@ -66,6 +66,7 @@ public:
 public slots:
 	bool clear(int priority, bool forceClearAll = false);
 	QJsonObject getAverageColor();
+	bool hasPriority(int priority);
 	hyperhdr::Components getComponentForPriority(int priority);
 	hyperhdr::Components getCurrentPriorityActiveComponent();
 	int getCurrentPriority() const;
@@ -96,6 +97,7 @@ public slots:
 	bool setVisiblePriority(int priority);
 	bool sourceAutoSelectEnabled() const;
 	void start();
+	void turnGrabbers(bool active);
 	void update();
 	void updateAdjustments(const QJsonObject& config);
 	void updateResult(std::vector<ColorRgb> _ledBuffer);

--- a/include/base/HyperHdrManager.h
+++ b/include/base/HyperHdrManager.h
@@ -62,7 +62,9 @@ public slots:
 
 	void toggleStateAllInstances(bool pause = false);
 
-	void hibernate(bool wakeUp);
+	void toggleGrabbersAllInstances(bool pause = false);
+
+	void hibernate(bool wakeUp, hyperhdr::SystemComponent source);
 
 	bool createInstance(const QString& name, bool start = false);
 

--- a/include/utils/Components.h
+++ b/include/utils/Components.h
@@ -96,4 +96,6 @@ namespace hyperhdr
 		if (cmp == "PROTOSERVER")   return COMP_PROTOSERVER;
 		return COMP_INVALID;
 	}
+
+	enum SystemComponent { SUSPEND, LOCKER, MONITOR };
 }

--- a/sources/base/ComponentController.cpp
+++ b/sources/base/ComponentController.cpp
@@ -106,3 +106,26 @@ void ComponentController::setNewComponentState(hyperhdr::Components comp, bool a
 		emit SignalComponentStateChanged(comp, activated);
 	}
 }
+
+void ComponentController::turnGrabbers(bool activated)
+{
+	if (_prevGrabbers.empty() && !activated)
+	{
+		_prevGrabbers.emplace(COMP_SYSTEMGRABBER, isComponentEnabled(COMP_SYSTEMGRABBER));
+		_prevGrabbers.emplace(COMP_VIDEOGRABBER, isComponentEnabled(COMP_VIDEOGRABBER));
+		for (const auto& comp : _prevGrabbers)
+			if (comp.second)
+			{
+				emit SignalRequestComponent(comp.first, false);
+			}
+	}
+	else if (!_prevGrabbers.empty() && activated)
+	{		
+		for (const auto& comp : _prevGrabbers)				
+			if (comp.second)
+			{
+				emit SignalRequestComponent(comp.first, true);
+			}
+		_prevGrabbers.clear();
+	}
+}

--- a/sources/base/HyperHdrInstance.cpp
+++ b/sources/base/HyperHdrInstance.cpp
@@ -617,6 +617,11 @@ int HyperHdrInstance::getCurrentPriority() const
 	return _muxer->getCurrentPriority();
 }
 
+bool HyperHdrInstance::hasPriority(int priority)
+{
+	return _muxer->hasPriority(priority);
+}
+
 hyperhdr::Components HyperHdrInstance::getComponentForPriority(int priority)
 {
 	return _muxer->getInputInfo(priority).componentId;
@@ -1031,4 +1036,10 @@ int HyperHdrInstance::hasLedClock()
 bool HyperHdrInstance::getScanParameters(size_t led, double& hscanBegin, double& hscanEnd, double& vscanBegin, double& vscanEnd) const
 {
 	return _imageProcessor->getScanParameters(led, hscanBegin, hscanEnd, vscanBegin, vscanEnd);
+}
+
+
+void HyperHdrInstance::turnGrabbers(bool active)
+{
+	_componentController->turnGrabbers(active);
 }

--- a/sources/blackborder/BlackBorderDetector.cpp
+++ b/sources/blackborder/BlackBorderDetector.cpp
@@ -85,7 +85,7 @@ BlackBorder BlackBorderDetector::process(const Image<ColorRgb>& image) const
 	}
 
 	// Construct result
-	BlackBorder detectedBorder;
+	BlackBorder detectedBorder{};
 
 	detectedBorder.unknown = firstNonBlackXPixelIndex == -1 || firstNonBlackYPixelIndex == -1;
 	detectedBorder.horizontalSize = firstNonBlackYPixelIndex;
@@ -143,7 +143,7 @@ BlackBorder BlackBorderDetector::process_classic(const Image<ColorRgb>& image) c
 	}
 
 	// Construct result
-	BlackBorder detectedBorder;
+	BlackBorder detectedBorder{};
 
 	detectedBorder.unknown = firstNonBlackXPixelIndex == -1 || firstNonBlackYPixelIndex == -1;
 	detectedBorder.horizontalSize = firstNonBlackYPixelIndex;
@@ -202,7 +202,7 @@ BlackBorder BlackBorderDetector::process_osd(const Image<ColorRgb>& image) const
 	}
 
 	// Construct result
-	BlackBorder detectedBorder;
+	BlackBorder detectedBorder{};
 	detectedBorder.unknown = firstNonBlackXPixelIndex == -1 || firstNonBlackYPixelIndex == -1;
 	detectedBorder.horizontalSize = firstNonBlackYPixelIndex;
 	detectedBorder.verticalSize = firstNonBlackXPixelIndex;
@@ -244,7 +244,7 @@ BlackBorder BlackBorderDetector::process_letterbox(const Image<ColorRgb>& image)
 	}
 
 	// Construct result
-	BlackBorder detectedBorder;
+	BlackBorder detectedBorder{};
 
 	detectedBorder.unknown = firstNonBlackYPixelIndex == -1;
 	detectedBorder.horizontalSize = firstNonBlackYPixelIndex;

--- a/sources/hyperhdr/SuspendHandlerLinux.cpp
+++ b/sources/hyperhdr/SuspendHandlerLinux.cpp
@@ -80,12 +80,12 @@ void SuspendHandler::sleeping(bool sleep)
 	if (sleep)
 	{
 		std::cout << "OS event: going sleep" << std::endl;
-		emit SignalHibernate(false);
+		emit SignalHibernate(false, hyperhdr::SystemComponent::SUSPEND);
 	}
 	else
 	{
 		std::cout << "OS event: wake up" << std::endl;
-		emit SignalHibernate(true);
+		emit SignalHibernate(true, hyperhdr::SystemComponent::SUSPEND);
 	}
 }
 

--- a/sources/hyperhdr/SuspendHandlerLinux.h
+++ b/sources/hyperhdr/SuspendHandlerLinux.h
@@ -26,7 +26,8 @@
 *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 *  SOFTWARE.
  */
- #include <QObject>
+#include <QObject>
+#include <utils/Components.h>
 
 #define HAVE_POWER_MANAGEMENT
 
@@ -34,7 +35,7 @@ class SuspendHandler : public QObject {
 	Q_OBJECT
 
 signals:
-	void SignalHibernate(bool wakeUp);
+	void SignalHibernate(bool wakeUp, hyperhdr::SystemComponent source);
 
 public:
 	SuspendHandler(bool sessionLocker = false);

--- a/sources/hyperhdr/SuspendHandlerMacOS.h
+++ b/sources/hyperhdr/SuspendHandlerMacOS.h
@@ -26,7 +26,8 @@
 *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 *  SOFTWARE.
  */
- #include <QObject>
+#include <QObject>
+#include <utils/Components.h>
 
 #define HAVE_POWER_MANAGEMENT
 
@@ -34,7 +35,7 @@ class SuspendHandler : public QObject {
 	Q_OBJECT
 
 signals:
-	void SignalHibernate(bool wakeUp);
+	void SignalHibernate(bool wakeUp, hyperhdr::SystemComponent source);
 
 public:
 	SuspendHandler(bool sessionLocker = false);

--- a/sources/hyperhdr/SuspendHandlerMacOS.mm
+++ b/sources/hyperhdr/SuspendHandlerMacOS.mm
@@ -77,14 +77,14 @@ namespace {
 - (void)goingSleep: (NSNotification*)note
 {
 	if (_suspendHandler != nullptr)
-		emit _suspendHandler->SignalHibernate(false);
+		emit _suspendHandler->SignalHibernate(false, hyperhdr::SystemComponent::SUSPEND);
 }
 
 
 - (void)goingWake: (NSNotification*)note
 {
 	if (_suspendHandler != nullptr)
-		emit _suspendHandler->SignalHibernate(true);
+		emit _suspendHandler->SignalHibernate(true, hyperhdr::SystemComponent::SUSPEND);
 }
 
 @end

--- a/sources/hyperhdr/SuspendHandlerWindows.h
+++ b/sources/hyperhdr/SuspendHandlerWindows.h
@@ -33,17 +33,19 @@
 #define NOMINMAX
 #include <windows.h>
 
+#include <utils/Components.h>
+
 #define HAVE_POWER_MANAGEMENT
 
 class SuspendHandler : public QObject, public QAbstractNativeEventFilter {
 	Q_OBJECT
 
 	QWidget			_widget;
-	HPOWERNOTIFY	_notifyHandle;
+	HPOWERNOTIFY	_notifyHandle, _notifyMonitorHandle;
 	bool			_sessionLocker;
 
 signals:
-	void SignalHibernate(bool wakeUp);
+	void SignalHibernate(bool wakeUp, hyperhdr::SystemComponent source);
 
 public:
 	SuspendHandler(bool sessionLocker = false);


### PR DESCRIPTION
The first batch of changes was introduced in this PR: https://github.com/awawa-dev/HyperHDR/pull/737

Now the functionality of turning off/waking up HyperHDR when the system is locked has been extended (Windows):
- if the background effect is set, the LEDs are not turned off, the effect works despite the system being locked, but the USB grabber and the system grabber are turned off to reduce the resource load
- if an OS event about the monitor turning off is detected, the same behavior occurs as when the system is locked (possibly turning off the LEDs and grabbers or resuming them later).
HyperHDR returns to its original state after unlocking the system or turning the monitor back on.