### PR TITLE
Fix background music effect

### DIFF
--- a/.github/actions/codeql/action.yml
+++ b/.github/actions/codeql/action.yml
@@ -69,7 +69,8 @@ runs:
   # If this step fails, then you should remove it and run the build manually (see below)
   - name: Autobuild
     uses: github/codeql-action/autobuild@v3
-
+    env:
+      CODEQL_EXTRACTOR_CPP_AUTOINSTALL_DEPENDENCIES: false
   # ℹ️ Command-line programs to run using the OS shell.
   # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fix background music effect #761 (v20 beta2 🆕)
+- Fix typo #762 Thanks @laurens94 (v20 beta2 🆕)
 - Yeelight: Wizard now supports more models, workaround for music-mode reset, auto-resume support #750 Thanks @ratawhisk (v20 beta2 🆕)
 - Fix verbose command line option #737 (v20 beta2 🆕)
 - Add native build for Apple M1 / M2 (arm64) architecture #973 (v20 beta2 🆕)

--- a/sources/effectengine/AnimationBaseMusic.cpp
+++ b/sources/effectengine/AnimationBaseMusic.cpp
@@ -30,14 +30,14 @@
 #include <utils/GlobalSignals.h>
 
 AnimationBaseMusic::AnimationBaseMusic(QString name) :
-	AnimationBase(name)
+	AnimationBase(name),
+	_soundCapture(nullptr),
+	_soundHandle(0)
 {
 	_myTarget.Clear();
 
 	emit GlobalSignals::getInstance()->SignalGetSoundCapture(_soundCapture);
-	if (_soundCapture != nullptr)
-		SAFE_CALL_0_RET(_soundCapture.get(), open, uint32_t, _soundHandle)
-	else
+	if (_soundCapture == nullptr)
 		setStopMe(true);	
 };
 
@@ -49,6 +49,11 @@ AnimationBaseMusic::~AnimationBaseMusic()
 
 bool AnimationBaseMusic::isSoundEffect()
 {
+	if (_soundHandle == 0 && _soundCapture != nullptr)
+	{
+		SAFE_CALL_0_RET(_soundCapture.get(), open, uint32_t, _soundHandle)
+	}
+
 	return true;
 };
 

--- a/sources/effectengine/Effect.cpp
+++ b/sources/effectengine/Effect.cpp
@@ -138,7 +138,7 @@ void Effect::start()
 
 	_timer.setInterval(_effect->GetSleepTime());
 
-	Info(_log, "Begin playing the effect with priority: %i", _priority);
+	Info(_log, "Begin playing the %s with priority: %i", (_effect->isSoundEffect()) ? "music effect" : "effect", _priority);
 
 	run();
 	_timer.start();	


### PR DESCRIPTION
If a background music effect is set, it may prevent the HyperHDR web interface from starting and working properly.
Fixes #760 