### PR TITLE
Fix critical LUt memory bug

### DIFF
--- a/sources/base/Grabber.cpp
+++ b/sources/base/Grabber.cpp
@@ -478,7 +478,7 @@ void Grabber::loadLutFile(PixelFormat color, const QList<QString>& files)
 
 					file.seek(index);
 
-					_lut.resize(length + 4);
+					_lut.resize(LUT_FILE_SIZE + 64);
 
 					if (file.read((char*)_lut.data(), LUT_FILE_SIZE) != LUT_FILE_SIZE)
 					{

--- a/sources/flatbufserver/FlatBufferServer.cpp
+++ b/sources/flatbufserver/FlatBufferServer.cpp
@@ -266,7 +266,7 @@ void FlatBufferServer::loadLutFile()
 
 					file.seek(index);
 
-					_lut.resize(length + 4);
+					_lut.resize(LUT_FILE_SIZE + 64);
 
 					if (file.read((char*)_lut.data(), LUT_FILE_SIZE) != LUT_FILE_SIZE)
 					{


### PR DESCRIPTION
When loading the LUT, memory was unnecessarily allocated to the entire 144MB LUT file instead of the selected 48MB sub-table. The fix reduces HyperHDR memory consumption by 96MB if a LUT was used (including YUV to RGB also in SDR, HDR tone mapping in USB grabbers or flatbuffers/protobuffers when full 144MB LUT table was used)