### PR TITLE
Switch xz to tukaani repo

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-    USE_CACHE: "0"
+    USE_CACHE: "1"
     RESET_CACHE: "0"
     USE_CODEQL: "1"
     BUILD_ARCHIVES: ${{ startsWith(github.event.ref, 'refs/tags') && 1 || 0 }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,10 @@
 	path = external/qmqtt
 	url = https://github.com/emqx/qmqtt.git
 	ignore = dirty
-[submodule "external/xz"]
-	path = external/xz
-	url = https://github.com/tukaani-project/xz.git
 [submodule "external/mdns"]
 	path = external/mdns
 	url = https://github.com/mjansson/mdns.git
+[submodule "external/xz"]
+	path = external/xz
+	url = https://git.tukaani.org/xz.git
+	branch = v5.2


### PR DESCRIPTION
Due to CVE-2024-3094 XZ repo from Github was removed and currently the build process fails.
Switched to the original XZ repo and the older branch until everything clears up.
HyperHDR used the older version 5.4.3 as a submodule (basically only for Windows, as it tried to use system libraries otherwise), so this had no effect, since the attack on Linux was performed on versions 5.6.0-5.6.1 in February  (has never arrived for Debian/Ubuntu/Fedora stable versions anyway). Also, the HyperHDR only release for rolling distro (Arch Linux) was built on docker from 19 January, also before the attack, and uses version 5.4.6.