### PR TITLE
Add NV12 image format support for flatbuffers!

### DIFF
--- a/include/base/Grabber.h
+++ b/include/base/Grabber.h
@@ -17,6 +17,7 @@
 #include <utils/Components.h>
 #include <image/MemoryBuffer.h>
 #include <utils/FrameDecoder.h>
+#include <utils/LutLoader.h>
 #include <base/DetectionManual.h>
 #include <base/DetectionAutomatic.h>
 #include <performance-counters/PerformanceCounters.h>
@@ -32,11 +33,9 @@
 	#include <CoreGraphics/CoreGraphics.h>
 #endif
 
-#define LUT_FILE_SIZE 50331648
-
 #define UNSUPPORTED_DECODER "UNSUPPORTED YUV DECODER"
 
-class Grabber : public DetectionAutomatic, public DetectionManual
+class Grabber : public DetectionAutomatic, public DetectionManual, protected LutLoader
 {
 	Q_OBJECT
 
@@ -174,7 +173,6 @@ signals:
 	void SignalBenchmarkUpdate(int status, QString message);
 
 protected:
-	void loadLutFile(PixelFormat color, const QList<QString>& files);
 
 	int getTargetSystemFrameDimension(int& targetSizeX, int& targetSizeY);
 
@@ -234,9 +232,6 @@ protected:
 
 	bool _enabled;
 
-	// enable/disable HDR tone mapping
-	uint8_t _hdrToneMappingEnabled;
-
 	/// logger instance
 	Logger* _log;
 
@@ -266,8 +261,6 @@ protected:
 	int			_actualWidth, _actualHeight, _actualFPS;
 	QString		_actualDeviceName;
 	uint		_targetMonitorNits;
-	MemoryBuffer<uint8_t>	_lut;
-	bool		_lutBufferInit;
 
 	int			_lineLength;
 	int			_frameByteSize;

--- a/include/flatbuffers/parser/FlatBuffersParser.h
+++ b/include/flatbuffers/parser/FlatBuffersParser.h
@@ -32,6 +32,30 @@
 namespace FlatBuffersParser
 {
 	enum FLATBUFFERS_PACKAGE_TYPE { COLOR = 1, IMAGE, CLEAR, PRIORITY, ERROR };
+	enum FLATBUFFERS_IMAGE_FORMAT { RGB = 1, NV12 };
+
+	struct FlatbuffersColor
+	{
+		uint8_t red;
+		uint8_t green;
+		uint8_t blue;
+	};
+
+	struct FlatbuffersTransientImage
+	{
+		FLATBUFFERS_IMAGE_FORMAT format;
+
+		struct
+		{
+			uint8_t* data;
+			int	size;
+			int	stride;
+		} firstPlane, secondPlane;
+		
+		int width;
+		int height;
+		int size;
+	};
 
 
 	void* createFlatbuffersBuilder();
@@ -43,8 +67,8 @@ namespace FlatBuffersParser
 	void encodeColorIntoFlatbuffers(void* builder, int red, int green, int blue, int priority, int duration, uint8_t** buffer, size_t* bufferSize);
 	bool verifyFlatbuffersReplyBuffer(const uint8_t* messageData, size_t messageSize, bool* _sent, bool* _registered, int* _priority);
 	int decodeIncomingFlatbuffersFrame(void* builder, const uint8_t* messageData, size_t messageSize,
-		uint8_t* red, uint8_t* green, uint8_t* blue,
 		int* priority, std::string* clientDescription, int* duration,
-		uint8_t** imageData, int* imageWidth, int* imageHeight, size_t* imageSize,
+		FlatbuffersTransientImage& image,
+		FlatbuffersColor& color,
 		uint8_t** buffer, size_t* bufferSize);
 }

--- a/include/flatbuffers/parser/hyperhdr_request.fbs
+++ b/include/flatbuffers/parser/hyperhdr_request.fbs
@@ -12,7 +12,16 @@ table RawImage {
   height:int = -1;
 }
 
-union ImageType {RawImage}
+table NV12Image {
+  data_y:[ubyte];
+  data_uv:[ubyte];
+  width:int = -1;
+  height:int = -1;
+  stride_y:int = -1;
+  stride_uv:int = -1;
+}
+
+union ImageType {RawImage, NV12Image}
 
 table Image {
   data:ImageType (required);

--- a/include/flatbuffers/parser/hyperhdr_request.fbs
+++ b/include/flatbuffers/parser/hyperhdr_request.fbs
@@ -15,10 +15,10 @@ table RawImage {
 table NV12Image {
   data_y:[ubyte];
   data_uv:[ubyte];
-  width:int = -1;
-  height:int = -1;
-  stride_y:int = -1;
-  stride_uv:int = -1;
+  width:int;
+  height:int;
+  stride_y:int = 0;
+  stride_uv:int = 0;
 }
 
 union ImageType {RawImage, NV12Image}

--- a/include/flatbuffers/server/FlatBuffersServer.h
+++ b/include/flatbuffers/server/FlatBuffersServer.h
@@ -9,6 +9,7 @@
 #include <utils/settings.h>
 #include <image/Image.h>
 #include <utils/Components.h>
+#include <utils/LutLoader.h>
 
 class BonjourServiceRegister;
 class QTcpServer;
@@ -16,10 +17,15 @@ class QLocalServer;
 class FlatBuffersServerConnection;
 class NetOrigin;
 
+namespace FlatBuffersParser
+{
+	struct FlatbuffersTransientImage;
+};
+
 #define HYPERHDR_DOMAIN_SERVER QStringLiteral("hyperhdr-domain")
 #define BASEAPI_FLATBUFFER_USER_LUT_FILE QStringLiteral("BASEAPI_user_lut_file")
 
-class FlatBuffersServer : public QObject
+class FlatBuffersServer : public QObject, protected LutLoader
 {
 	Q_OBJECT
 public:
@@ -35,7 +41,7 @@ public slots:
 	void initServer();
 	int getHdrToneMappingEnabled();
 	void handlerImportFromProto(int priority, int duration, const Image<ColorRgb>& image, QString clientDescription);
-	void handlerImageReceived(int priority, const Image<ColorRgb>& image, int timeout_ms, hyperhdr::Components origin, QString clientDescription);
+	void handlerImageReceived(int priority, FlatBuffersParser::FlatbuffersTransientImage* flatImage, int timeout_ms, hyperhdr::Components origin, QString clientDescription);
 	void signalRequestSourceHandler(hyperhdr::Components component, int instanceIndex, bool listen);
 
 private slots:
@@ -60,11 +66,8 @@ private:
 	BonjourServiceRegister* _serviceRegister = nullptr;
 	QVector<FlatBuffersServerConnection*> _openConnections;
 
-	int			_hdrToneMappingMode;
-	int			_realHdrToneMappingMode;	
-	bool		_lutBufferInit;
 	QString		_configurationPath;
 	QString		_userLutFile;
-
-	MemoryBuffer<uint8_t> _lut;
+	PixelFormat	_currentLutPixelFormat;
+	int			_flatbufferToneMappingMode;
 };

--- a/include/flatbuffers/server/FlatBuffersServerConnection.h
+++ b/include/flatbuffers/server/FlatBuffersServerConnection.h
@@ -37,6 +37,10 @@
 class QTcpSocket;
 class QLocalSocket;
 class QTimer;
+namespace FlatBuffersParser
+{
+	struct FlatbuffersTransientImage;
+};
 
 class FlatBuffersServerConnection : public QObject
 {
@@ -49,7 +53,7 @@ public:
 
 signals:
 	void SignalClearGlobalInput(int priority, bool forceClearAll);
-	void SignalImageReceived(int priority, const Image<ColorRgb>& image, int timeout_ms, hyperhdr::Components origin, QString clientDescription);
+	void SignalDirectImageReceivedInTempBuffer(int priority, FlatBuffersParser::FlatbuffersTransientImage* image, int timeout_ms, hyperhdr::Components origin, QString clientDescription);
 	void SignalSetGlobalColor(int priority, const std::vector<ColorRgb>& ledColor, int timeout_ms, hyperhdr::Components origin, QString clientDescription);
 	void SignalClientDisconnected(FlatBuffersServerConnection* client);
 

--- a/include/image/ColorRgb.h
+++ b/include/image/ColorRgb.h
@@ -91,7 +91,7 @@ struct ColorRgb
 	operator std::string()
 	{
 		std::stringstream ss;
-		ss << "(" << red << ", " << green << ", " << blue << ")";
+		ss << "(" << std::to_string(red) << ", " << std::to_string(green) << ", " << std::to_string(blue) << ")";
 		return ss.str();
 	}
 

--- a/include/utils/FrameDecoder.h
+++ b/include/utils/FrameDecoder.h
@@ -13,7 +13,7 @@ class FrameDecoder
 public:
 	static void processImage(
 		int _cropLeft, int _cropRight, int _cropTop, int _cropBottom,
-		const uint8_t* data, int width, int height, int lineLength,
+		const uint8_t* data, const uint8_t* dataUV, int width, int height, int lineLength,
 		const PixelFormat pixelFormat, const uint8_t* lutBuffer, Image<ColorRgb>& outputImage);
 
 	static void processQImage(

--- a/include/utils/LutLoader.h
+++ b/include/utils/LutLoader.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifndef PCH_ENABLED
+	#include <QString>
+	#include <QList>
+#endif
+
+#include <utils/PixelFormat.h>
+#include <image/MemoryBuffer.h>
+#include <utils/Logger.h>
+
+class LutLoader {
+	public:
+		int		_hdrToneMappingEnabled = 0;
+		bool	_lutBufferInit = false;
+
+		MemoryBuffer<uint8_t>	_lut;		
+
+		void loadLutFile(Logger* _log, PixelFormat color, const QList<QString>& files);
+};

--- a/sources/flatbuffers/server/FlatBuffersServer.cpp
+++ b/sources/flatbuffers/server/FlatBuffersServer.cpp
@@ -284,8 +284,6 @@ void FlatBuffersServer::handlerImportFromProto(int priority, int duration, const
 
 void FlatBuffersServer::handlerImageReceived(int priority, FlatBuffersParser::FlatbuffersTransientImage* flatImage, int timeout_ms, hyperhdr::Components origin, QString clientDescription)
 {
-	static unsigned int logger = 0;
-
 	if (QThread::currentThread() != this->thread())
 	{
 		Error(_log, "Sanity check. FlatBuffersServer::handlerImageReceived uses the wrong thread affiliation.");
@@ -298,15 +296,7 @@ void FlatBuffersServer::handlerImageReceived(int priority, FlatBuffersParser::Fl
 		{
 			_currentLutPixelFormat = PixelFormat::RGB24;
 			loadLutFile();
-			logger = 0;
 		}
-
-		if (logger++ < 10)
-		{
-			Debug(_log, "RGB flatbuffers frame (%i)", logger);
-		}
-
-
 
 		if (flatImage->size != flatImage->width * flatImage->height * 3)
 		{
@@ -334,14 +324,7 @@ void FlatBuffersServer::handlerImageReceived(int priority, FlatBuffersParser::Fl
 				flatImage->firstPlane.size, flatImage->firstPlane.stride,
 				flatImage->secondPlane.size, flatImage->secondPlane.stride,
 				flatImage->size, flatImage->width, flatImage->height);
-			logger = 0;
 		}
-
-		if (logger++ < 10)
-		{
-			Debug(_log, "NV12 flatbuffers frame (%i)", logger);
-		}
-
 
 		if (!_lutBufferInit)
 		{

--- a/sources/flatbuffers/server/FlatBuffersServer.cpp
+++ b/sources/flatbuffers/server/FlatBuffersServer.cpp
@@ -284,6 +284,8 @@ void FlatBuffersServer::handlerImportFromProto(int priority, int duration, const
 
 void FlatBuffersServer::handlerImageReceived(int priority, FlatBuffersParser::FlatbuffersTransientImage* flatImage, int timeout_ms, hyperhdr::Components origin, QString clientDescription)
 {
+	static unsigned int logger = 0;
+
 	if (QThread::currentThread() != this->thread())
 	{
 		Error(_log, "Sanity check. FlatBuffersServer::handlerImageReceived uses the wrong thread affiliation.");
@@ -296,7 +298,15 @@ void FlatBuffersServer::handlerImageReceived(int priority, FlatBuffersParser::Fl
 		{
 			_currentLutPixelFormat = PixelFormat::RGB24;
 			loadLutFile();
+			logger = 0;
 		}
+
+		if (logger++ < 10)
+		{
+			Debug(_log, "RGB flatbuffers frame (%i)", logger);
+		}
+
+
 
 		if (flatImage->size != flatImage->width * flatImage->height * 3)
 		{
@@ -324,7 +334,14 @@ void FlatBuffersServer::handlerImageReceived(int priority, FlatBuffersParser::Fl
 				flatImage->firstPlane.size, flatImage->firstPlane.stride,
 				flatImage->secondPlane.size, flatImage->secondPlane.stride,
 				flatImage->size, flatImage->width, flatImage->height);
+			logger = 0;
 		}
+
+		if (logger++ < 10)
+		{
+			Debug(_log, "NV12 flatbuffers frame (%i)", logger);
+		}
+
 
 		if (!_lutBufferInit)
 		{

--- a/sources/grabber/linux/v4l2/V4L2Grabber.cpp
+++ b/sources/grabber/linux/v4l2/V4L2Grabber.cpp
@@ -112,7 +112,7 @@ void V4L2Grabber::loadLutFile(PixelFormat color)
 	QString fileName2 = QString("%1%2").arg(GetSharedLut()).arg("/lut_lin_tables.3d");
 	QString fileName3 = QString("/usr/share/hyperhdr/lut/lut_lin_tables.3d");
 
-	Grabber::loadLutFile(color, QList<QString>{fileName1, fileName2, fileName3});
+	Grabber::loadLutFile(_log, color, QList<QString>{fileName1, fileName2, fileName3});
 }
 
 void V4L2Grabber::setHdrToneMappingEnabled(int mode)

--- a/sources/grabber/linux/v4l2/V4L2Worker.cpp
+++ b/sources/grabber/linux/v4l2/V4L2Worker.cpp
@@ -222,7 +222,7 @@ void V4L2Worker::runMe()
 
 				FrameDecoder::processImage(
 					_cropLeft, _cropRight, _cropTop, _cropBottom,
-					_sharedData, _width, _height, _lineLength, _pixelFormat, _lutBuffer, image);
+					_sharedData, nullptr, _width, _height, _lineLength, _pixelFormat, _lutBuffer, image);
 
 				image.setBufferCacheSize();
 				if (!_directAccess)
@@ -296,7 +296,7 @@ void V4L2Worker::process_image_jpg_mt()
 		}
 
 		FrameDecoder::processImage(_cropLeft, _cropRight, _cropTop, _cropBottom,
-			jpgBuffer.data(), _width, _height, _width, (_subsamp == TJSAMP_422) ? PixelFormat::MJPEG : PixelFormat::I420, _lutBuffer, image);
+			jpgBuffer.data(), nullptr, _width, _height, _width, (_subsamp == TJSAMP_422) ? PixelFormat::MJPEG : PixelFormat::I420, _lutBuffer, image);
 	}
 	else if (image.width() != (uint)_width || image.height() != (uint)_height)
 	{
@@ -310,7 +310,7 @@ void V4L2Worker::process_image_jpg_mt()
 		}
 
 		FrameDecoder::processImage(_cropLeft, _cropRight, _cropTop, _cropBottom,
-			jpgBuffer.data(), _width, _height, _width * 3, PixelFormat::RGB24, nullptr, image);
+			jpgBuffer.data(), nullptr, _width, _height, _width * 3, PixelFormat::RGB24, nullptr, image);
 	}
 	else
 	{

--- a/sources/grabber/osx/AVF/AVFGrabber.mm
+++ b/sources/grabber/osx/AVF/AVFGrabber.mm
@@ -182,7 +182,7 @@ void AVFGrabber::loadLutFile(PixelFormat color)
 	QString fileName1 = QString("%1%2").arg(_configurationPath).arg("/lut_lin_tables.3d");
 	QString fileName2 = QString("%1%2").arg(GetSharedLut()).arg("/lut_lin_tables.3d");
 
-	Grabber::loadLutFile(color, QList<QString>{fileName1, fileName2});
+	Grabber::loadLutFile(_log, color, QList<QString>{fileName1, fileName2});
 }
 
 void AVFGrabber::setHdrToneMappingEnabled(int mode)

--- a/sources/grabber/osx/AVF/AVFWorker.cpp
+++ b/sources/grabber/osx/AVF/AVFWorker.cpp
@@ -213,7 +213,7 @@ void AVFWorker::runMe()
 
 			FrameDecoder::processImage(
 				_cropLeft, _cropRight, _cropTop, _cropBottom,
-				_localBuffer.data(), _width, _height, _lineLength, _pixelFormat, _lutBuffer, image);
+				_localBuffer.data(), nullptr, _width, _height, _lineLength, _pixelFormat, _lutBuffer, image);
 
 			image.setBufferCacheSize();
 			if (!_directAccess)

--- a/sources/grabber/windows/DX/DxGrabber.cpp
+++ b/sources/grabber/windows/DX/DxGrabber.cpp
@@ -112,7 +112,7 @@ void DxGrabber::loadLutFile(PixelFormat color)
 	QString fileName1 = QString("%1%2").arg(_configurationPath).arg("/lut_lin_tables.3d");
 	QString fileName2 = QString("%1%2").arg(GetSharedLut()).arg("/lut_lin_tables.3d");
 
-	Grabber::loadLutFile(color, QList<QString>{fileName1, fileName2});
+	Grabber::loadLutFile(_log, color, QList<QString>{fileName1, fileName2});
 }
 
 void DxGrabber::setHdrToneMappingEnabled(int mode)

--- a/sources/grabber/windows/MF/MFGrabber.cpp
+++ b/sources/grabber/windows/MF/MFGrabber.cpp
@@ -172,7 +172,7 @@ void MFGrabber::loadLutFile(PixelFormat color)
 	QString fileName1 = QString("%1%2").arg(_configurationPath).arg("/lut_lin_tables.3d");
 	QString fileName2 = QString("%1%2").arg(GetSharedLut()).arg("/lut_lin_tables.3d");
 
-	Grabber::loadLutFile(color, QList<QString>{fileName1, fileName2});
+	Grabber::loadLutFile(_log, color, QList<QString>{fileName1, fileName2});
 }
 
 void MFGrabber::setHdrToneMappingEnabled(int mode)

--- a/sources/grabber/windows/MF/MFWorker.cpp
+++ b/sources/grabber/windows/MF/MFWorker.cpp
@@ -217,7 +217,7 @@ void MFWorker::runMe()
 
 				FrameDecoder::processImage(
 					_cropLeft, _cropRight, _cropTop, _cropBottom,
-					_localBuffer.data(), _width, _height, _lineLength, _pixelFormat, _lutBuffer, image);
+					_localBuffer.data(), nullptr, _width, _height, _lineLength, _pixelFormat, _lutBuffer, image);
 
 				image.setBufferCacheSize();
 				if (!_directAccess)
@@ -290,7 +290,7 @@ void MFWorker::process_image_jpg_mt()
 			}		
 
 		FrameDecoder::processImage(_cropLeft, _cropRight, _cropTop, _cropBottom,
-			jpgBuffer.data(), _width, _height, _width, (_subsamp == TJSAMP_422) ? PixelFormat::MJPEG : PixelFormat::I420, _lutBuffer, image);
+			jpgBuffer.data(), nullptr, _width, _height, _width, (_subsamp == TJSAMP_422) ? PixelFormat::MJPEG : PixelFormat::I420, _lutBuffer, image);
 	}
 	else if (image.width() != (uint)_width || image.height() != (uint)_height)
 	{
@@ -304,7 +304,7 @@ void MFWorker::process_image_jpg_mt()
 			}					
 		
 		FrameDecoder::processImage(_cropLeft, _cropRight, _cropTop, _cropBottom,
-			jpgBuffer.data(), _width, _height, _width * 3, PixelFormat::RGB24, nullptr, image);
+			jpgBuffer.data(), nullptr, _width, _height, _width * 3, PixelFormat::RGB24, nullptr, image);
 	}
 	else
 	{

--- a/sources/lut-calibrator/LutCalibrator.cpp
+++ b/sources/lut-calibrator/LutCalibrator.cpp
@@ -39,7 +39,7 @@
 	#include <utils/Logger.h>
 #endif
 
-#define STRING_CSTR(x) ((std::string)x).c_str()
+#define STRING_CSTR(x) (x.operator std::string()).c_str()
 
 #include <QCoreApplication>
 
@@ -178,6 +178,16 @@ void LutCalibrator::incomingCommand(QString rootpath, GrabberWrapper* grabberWra
 				QThread::msleep(2000);
 
 				_log->enable();
+			}
+			else
+			{
+				Debug(_log, "Reloading LUT 1/2");
+				emit GlobalSignals::getInstance()->SignalRequestComponent(hyperhdr::Components::COMP_HDR, -1, true);
+				QThread::msleep(2000);
+				Debug(_log, "Reloading LUT 2/2");
+				emit GlobalSignals::getInstance()->SignalRequestComponent(hyperhdr::Components::COMP_HDR, -1, false);
+				QThread::msleep(2000);
+				Debug(_log, "Finished reloading LUT");
 			}
 
 			if (defaultComp == hyperhdr::COMP_VIDEOGRABBER)

--- a/sources/utils/FrameDecoder.cpp
+++ b/sources/utils/FrameDecoder.cpp
@@ -38,7 +38,7 @@
 
 void FrameDecoder::processImage(
 	int _cropLeft, int _cropRight, int _cropTop, int _cropBottom,
-	const uint8_t* data, int width, int height, int lineLength,
+	const uint8_t* data, const uint8_t* dataUV, int width, int height, int lineLength,
 	const PixelFormat pixelFormat, const uint8_t* lutBuffer, Image<ColorRgb>& outputImage)
 {
 	uint32_t ind_lutd, ind_lutd2;
@@ -240,20 +240,20 @@ void FrameDecoder::processImage(
 
 	if (pixelFormat == PixelFormat::NV12)
 	{
-		int deltaU = lineLength * height;
+		auto deltaUV = (dataUV != nullptr) ? (uint8_t*)dataUV : (uint8_t*)data + lineLength * height;
 		for (int yDest = 0, ySource = _cropTop; yDest < outputHeight; ++ySource, ++yDest)
 		{
 			uint8_t* currentDest = destMemory + ((uint64_t)destLineSize) * yDest;
 			uint8_t* endDest = currentDest + destLineSize;
 			uint8_t* currentSource = (uint8_t*)data + (((uint64_t)lineLength * ySource) + ((uint64_t)_cropLeft));
-			uint8_t* currentSourceU = (uint8_t*)data + deltaU + (((uint64_t)ySource / 2) * lineLength) + ((uint64_t)_cropLeft);
+			uint8_t* currentSourceUV = deltaUV + (((uint64_t)ySource / 2) * lineLength) + ((uint64_t)_cropLeft);
 
 			while (currentDest < endDest)
 			{
 				*((uint16_t*)&buffer) = *((uint16_t*)currentSource);
 				currentSource += 2;
-				*((uint16_t*)&(buffer[2])) = *((uint16_t*)currentSourceU);
-				currentSourceU += 2;
+				*((uint16_t*)&(buffer[2])) = *((uint16_t*)currentSourceUV);
+				currentSourceUV += 2;
 
 				ind_lutd = LUT_INDEX(buffer[0], buffer[2], buffer[3]);
 				ind_lutd2 = LUT_INDEX(buffer[1], buffer[2], buffer[3]);

--- a/sources/utils/LutLoader.cpp
+++ b/sources/utils/LutLoader.cpp
@@ -1,0 +1,130 @@
+/* LutLoader.cpp
+*
+*  MIT License
+*
+*  Copyright (c) 2020-2024 awawa-dev
+*
+*  Project homesite: https://github.com/awawa-dev/HyperHDR
+*
+*  Permission is hereby granted, free of charge, to any person obtaining a copy
+*  of this software and associated documentation files (the "Software"), to deal
+*  in the Software without restriction, including without limitation the rights
+*  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*  copies of the Software, and to permit persons to whom the Software is
+*  furnished to do so, subject to the following conditions:
+*
+*  The above copyright notice and this permission notice shall be included in all
+*  copies or substantial portions of the Software.
+
+*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*  SOFTWARE.
+*/
+
+#include <utils/LutLoader.h>
+#include <image/ColorRgb.h>
+#include <utils/FrameDecoder.h>
+#include <QFile>
+
+namespace {
+	const int LUT_FILE_SIZE = 256 * 256 * 256 *3;
+	const int LUT_MEMORY_ALIGN = 64;
+}
+
+void LutLoader::loadLutFile(Logger* _log, PixelFormat color, const QList<QString>& files)
+{
+	bool is_yuv = (color == PixelFormat::YUYV);
+
+	_lutBufferInit = false;
+
+	if (color != PixelFormat::NO_CHANGE && color != PixelFormat::RGB24 && color != PixelFormat::YUYV)
+	{
+		Error(_log, "Unsupported mode for loading LUT table: %s", QSTRING_CSTR(pixelFormatToString(color)));
+		return;
+	}
+
+	if (color == PixelFormat::NO_CHANGE)
+	{
+		_lut.resize(LUT_FILE_SIZE + LUT_MEMORY_ALIGN);
+
+		if (_lut.data() != nullptr)
+		{
+			for (int y = 0; y < 256; y++)
+				for (int u = 0; u < 256; u++)
+					for (int v = 0; v < 256; v++)
+					{
+						uint32_t ind_lutd = LUT_INDEX(y, u, v);
+						ColorRgb::yuv2rgb(y, u, v,
+							_lut.data()[ind_lutd],
+							_lut.data()[ind_lutd + 1],
+							_lut.data()[ind_lutd + 2]);
+					}
+			_lutBufferInit = true;
+		}
+
+		Error(_log, "You have forgotten to put lut_lin_tables.3d file in the HyperHDR configuration folder. Internal LUT table for YUV conversion has been created instead.");
+		return;
+	}
+
+	if (_hdrToneMappingEnabled || is_yuv)
+	{
+		for (QString fileName3d : files)
+		{
+			QFile file(fileName3d);
+
+			if (file.open(QIODevice::ReadOnly))
+			{
+				int length;
+				Debug(_log, "LUT file found: %s", QSTRING_CSTR(fileName3d));
+
+				length = file.size();
+
+				if ((length == LUT_FILE_SIZE * 3) || (length == LUT_FILE_SIZE && !is_yuv))
+				{
+					qint64 index = 0;
+
+					if (is_yuv && _hdrToneMappingEnabled)
+					{
+						Debug(_log, "Index 1 for HDR YUV");
+						index = LUT_FILE_SIZE;
+					}
+					else if (is_yuv)
+					{
+						Debug(_log, "Index 2 for YUV");
+						index = LUT_FILE_SIZE * 2;
+					}
+					else
+						Debug(_log, "Index 0 for HDR RGB");
+
+					file.seek(index);
+
+					_lut.resize(LUT_FILE_SIZE + LUT_MEMORY_ALIGN);
+
+					if (file.read((char*)_lut.data(), LUT_FILE_SIZE) != LUT_FILE_SIZE)
+					{
+						Error(_log, "Error reading LUT file %s", QSTRING_CSTR(fileName3d));
+					}
+					else
+					{
+						_lutBufferInit = true;
+						Info(_log, "Found and loaded LUT: '%s'", QSTRING_CSTR(fileName3d));
+					}
+				}
+				else
+					Error(_log, "LUT file has invalid length: %i vs %i => %s", length, (LUT_FILE_SIZE * 3), QSTRING_CSTR(fileName3d));
+
+				file.close();
+
+				return;
+			}
+			else
+				Warning(_log, "LUT file is not found here: %s", QSTRING_CSTR(fileName3d));
+		}
+
+		Error(_log, "Could not find any required LUT file");
+	}
+}


### PR DESCRIPTION
Till recently HyperHDR flatbuffers server only supported raw RGB format. It had many limitation.
But thanks to @s1mptom for inspiration this PR adds NV12 image format to HyperHDR flatbuffers server (more discussion here: https://github.com/awawa-dev/HyperHDR/discussions/916) For now you can use it with rather exotic and unsupported here webos capturing application but it is intended to work with any client and in the future it will be easy to extend it to other formats such as mjpeg

Advantages:
- NV12 YUV conversion was completely moved to HyperHDR which uses LUT table for this purpose (zero calculations when converting YUV to RGB). Using selected LUT it can also perform YUV to RGB conversion and tone mapping in the same one step. This means we reduce the client load because in addition to reducing the processor load, it does not have to allocate additional resources, e.g. memory. You dont have to use external YUV libraries either.
- less load on the connection bandwidth. NV12 frame is about 50% size of the RGB frame.
- allows to fully utilize automatic LUT calibration with YUV coef detection

Important: 
- when NV12 transport mode is used HyperHDR needs standard full LUT table (150MB). The sometimes used small one (50MB) doesn't contain necessary YUV conversion tables and will work only for the RGB tone mapping.

My thought after receiving the sample frame (thanks again @s1mptom): when webos uses NV12 internally, as a consequence of using NV12 format there is only one color for every 4 brightness values. So even if webos capturing converts it like it does now to 320x240 RGB before sending the frame to HyperHDR, in reality we have only 160x120 colors and 320x240 pure brightness values blended together to achieve 320x240 RGB. Which can be important for dense LED strips, where you will need to use a higher resolution for a better effect. 
**But that's how internal webos capturing works so it's not a fault of the format since they chose it and we cant change it. However, we can abandon the unnecessary conversion from NV12 to RGB (which does not improve the quality at all and brings other problems) and send the original NV12 stream via flatbuffers now.**

Some results (webOS, thanks s1mptom):
```
2024-08-13T17:33:54.531Z [CALIBRATOR] (LutCalibrator.cpp:936) Mean error for FCC is: 9520.889295
2024-08-13T17:33:54.531Z [CALIBRATOR] (LutCalibrator.cpp:936) Mean error for REC.709 is: 7063.289823
2024-08-13T17:33:54.531Z [CALIBRATOR] (LutCalibrator.cpp:936) Mean error for REC.601 is: 9462.383205
```
YUV coefficients are switched during LUT calibration thanks to the native NV12 format. It was impossible for the RGB flatbuffers stream.


![image](https://github.com/user-attachments/assets/aa2d0a99-3397-4e81-aa17-4b4ffab6afcb)
[source](https://gist.github.com/Jim-Bar/3cbba684a71d1a9d468a6711a6eddbeb)

