### PR TITLE
Fix LED colors adjustments by configuration name

### DIFF
--- a/sources/led-strip/LedCalibration.cpp
+++ b/sources/led-strip/LedCalibration.cpp
@@ -160,6 +160,18 @@ QJsonArray LedCalibration::getAdjustmentState() const
 void LedCalibration::updateConfig(const QJsonObject& adjustment)
 {
 	if (_calibrationConfig.size() > 0)
+	{
+		const QString adjustmentId = adjustment["id"].toString(_calibrationConfig.front()->getId());
+
+		for (auto colorAdjustment = _calibrationConfig.cbegin(); colorAdjustment != _calibrationConfig.cend(); ++colorAdjustment)
+			if (adjustmentId == (*colorAdjustment)->getId())
+			{
+				(*colorAdjustment)->updateConfig(adjustment);
+				return;
+			}
+
+
 		_calibrationConfig.front()->updateConfig(adjustment);
+	}
 }
 


### PR DESCRIPTION
When trying to set the LED color option, e.g. luminance gain, in the case of having several configuration sections, it was always set first despite passing the identifier to another section.
This PR fixes: #953 