### PR TITLE
DX grabber: stick to user specified device selection

### DIFF
--- a/sources/grabber/windows/DX/DxGrabber.cpp
+++ b/sources/grabber/windows/DX/DxGrabber.cpp
@@ -205,8 +205,8 @@ bool DxGrabber::init()
 
 		if (!autoDiscovery && !_deviceProperties.contains(_deviceName))
 		{
-			Debug(_log, "Device %s is not available. Changing to auto.", QSTRING_CSTR(_deviceName));
-			autoDiscovery = true;
+			Error(_log, "User selected '%s' device is currently not available and the 'auto' discovery is disabled", QSTRING_CSTR(_deviceName));
+			return false;
 		}
 
 		if (autoDiscovery)
@@ -215,8 +215,7 @@ bool DxGrabber::init()
 			if (!_deviceProperties.isEmpty())
 			{
 				foundDevice = _deviceProperties.firstKey();
-				_deviceName = foundDevice;
-				Debug(_log, "Auto discovery set to %s", QSTRING_CSTR(_deviceName));
+				Debug(_log, "Auto discovery set to %s", QSTRING_CSTR(foundDevice));
 			}
 		}
 		else

--- a/sources/grabber/windows/DX/DxGrabber.cpp
+++ b/sources/grabber/windows/DX/DxGrabber.cpp
@@ -205,7 +205,9 @@ bool DxGrabber::init()
 
 		if (!autoDiscovery && !_deviceProperties.contains(_deviceName))
 		{
-			Error(_log, "User selected '%s' device is currently not available and the 'auto' discovery is disabled", QSTRING_CSTR(_deviceName));
+			_retryTimer->setInterval(5000);
+			_retryTimer->start();
+			Error(_log, "User selected '%s' device is currently not available and the 'auto' discovery is disabled. Retry in %.1f sec...", QSTRING_CSTR(_deviceName), _retryTimer->interval()/1000.0);
 			return false;
 		}
 


### PR DESCRIPTION
Resolves #779 , enables auto-retry if the device is currently not present