### PR TITLE
Add support for Home Assistant lights

### DIFF
--- a/include/bonjour/DiscoveryRecord.h
+++ b/include/bonjour/DiscoveryRecord.h
@@ -35,7 +35,7 @@
 class DiscoveryRecord
 {
 public:
-	enum Service { Unknown = 0, HyperHDR, WLED, PhilipsHue, Pico, ESP32_S2, ESP, SerialPort, REFRESH_ALL };
+	enum Service { Unknown = 0, HyperHDR, WLED, PhilipsHue, HomeAssistant, Pico, ESP32_S2, ESP, SerialPort, REFRESH_ALL };
 
 	Service type;
 	QString hostName;

--- a/include/bonjour/DiscoveryWrapper.h
+++ b/include/bonjour/DiscoveryWrapper.h
@@ -50,6 +50,7 @@ public:
 
 public slots:
 	QList<DiscoveryRecord> getPhilipsHUE();
+	QList<DiscoveryRecord> getHomeAssistant();
 	QList<DiscoveryRecord> getWLED();
 	QList<DiscoveryRecord> getHyperHDRServices();
 	QList<DiscoveryRecord> getAllServices();	
@@ -66,5 +67,5 @@ private:
 	void cleanUp(QList<DiscoveryRecord>& target);
 
 	// contains all current active service sessions
-	QList<DiscoveryRecord> _hyperhdrSessions, _wledDevices, _hueDevices, _espDevices, _picoDevices, _esp32s2Devices;
+	QList<DiscoveryRecord> _hyperhdrSessions, _wledDevices, _hueDevices, _homeAssistantDevices, _espDevices, _picoDevices, _esp32s2Devices;
 };

--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -2,6 +2,7 @@
 
 #ifndef PCH_ENABLED
 	#include <QJsonObject>
+	#include <QJsonArray>
 	#include <memory>
 	#include <list>	
 #endif
@@ -38,7 +39,7 @@ class DriverNetHomeAssistant : public LedDevice
 		{
 			int isPoweredOn = -1;
 			int brightness = -1;
-			linalg::aliases::int4 color{ -1, -1, -1, -1 };
+			QJsonArray color;
 		} orgState;
 	};
 
@@ -56,6 +57,8 @@ private:
 	bool init(const QJsonObject& deviceConfig) override;
 	int write(const std::vector<ColorRgb>& ledValues) override;
 	bool powerOnOff(bool isOn);
+	bool saveStates();
+	void restoreStates();
 
 	HomeAssistantInstance _haInstance;
 

--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <led-drivers/LedDevice.h>
+#include <linalg.h>
 
 class DriverNetHomeAssistant : public LedDevice
 {
@@ -15,4 +16,30 @@ private:
 	int write(const std::vector<ColorRgb>& ledValues) override;
 
 	static bool isRegistered;
+};
+
+struct HomeAssistantLamp;
+
+struct HomeAssistantInstance
+{
+	QString homeAssistantHost;
+	QString longLivedAccessToken;
+	bool restoreOriginalState;
+
+	std::list<HomeAssistantLamp> lamps;
+};
+
+struct HomeAssistantLamp
+{
+	enum Mode { RGB = 0, HSV };
+
+	QString name;
+	Mode colorModel;
+
+	struct
+	{
+		int isPoweredOn = -1;
+		int brightness = -1;
+		linalg::aliases::int4 color{ -1, -1, -1, -1 };
+	} orgState;
 };

--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -20,6 +20,8 @@ class DriverNetHomeAssistant : public LedDevice
 	{
 		QString homeAssistantHost;
 		QString longLivedAccessToken;
+		int transition;
+		int constantBrightness;
 		bool restoreOriginalState;
 
 		std::list<HomeAssistantLamp> lamps;

--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -1,6 +1,13 @@
 #pragma once
 
+#ifndef PCH_ENABLED
+	#include <QJsonObject>
+	#include <memory>
+	#include <list>	
+#endif
+
 #include <led-drivers/LedDevice.h>
+#include <led-drivers/net/ProviderRestApi.h>
 #include <linalg.h>
 
 class DriverNetHomeAssistant : public LedDevice
@@ -39,11 +46,18 @@ public:
 
 	QJsonObject discover(const QJsonObject& params) override;
 
+protected:
+	bool powerOn() override;
+	bool powerOff() override;
+
 private:
 	bool init(const QJsonObject& deviceConfig) override;
 	int write(const std::vector<ColorRgb>& ledValues) override;
+	bool powerOnOff(bool isOn);
 
 	HomeAssistantInstance _haInstance;
+
+	std::unique_ptr<ProviderRestApi> _restApi;
 
 	static bool isRegistered;
 };

--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -11,6 +11,8 @@ public:
 	explicit DriverNetHomeAssistant(const QJsonObject& deviceConfig);
 	static LedDevice* construct(const QJsonObject& deviceConfig);
 
+	QJsonObject discover(const QJsonObject& params) override;
+
 private:
 	bool init(const QJsonObject& deviceConfig) override;
 	int write(const std::vector<ColorRgb>& ledValues) override;

--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -7,6 +7,32 @@ class DriverNetHomeAssistant : public LedDevice
 {
 	Q_OBJECT
 
+	struct HomeAssistantLamp;
+
+	struct HomeAssistantInstance
+	{
+		QString homeAssistantHost;
+		QString longLivedAccessToken;
+		bool restoreOriginalState;
+
+		std::list<HomeAssistantLamp> lamps;
+	};
+
+	struct HomeAssistantLamp
+	{
+		enum Mode { RGB = 0, HSV };
+
+		QString name;
+		Mode colorModel;
+
+		struct
+		{
+			int isPoweredOn = -1;
+			int brightness = -1;
+			linalg::aliases::int4 color{ -1, -1, -1, -1 };
+		} orgState;
+	};
+
 public:
 	explicit DriverNetHomeAssistant(const QJsonObject& deviceConfig);
 	static LedDevice* construct(const QJsonObject& deviceConfig);
@@ -17,31 +43,7 @@ private:
 	bool init(const QJsonObject& deviceConfig) override;
 	int write(const std::vector<ColorRgb>& ledValues) override;
 
+	HomeAssistantInstance _haInstance;
+
 	static bool isRegistered;
-};
-
-struct HomeAssistantLamp;
-
-struct HomeAssistantInstance
-{
-	QString homeAssistantHost;
-	QString longLivedAccessToken;
-	bool restoreOriginalState;
-
-	std::list<HomeAssistantLamp> lamps;
-};
-
-struct HomeAssistantLamp
-{
-	enum Mode { RGB = 0, HSV };
-
-	QString name;
-	Mode colorModel;
-
-	struct
-	{
-		int isPoweredOn = -1;
-		int brightness = -1;
-		linalg::aliases::int4 color{ -1, -1, -1, -1 };
-	} orgState;
 };

--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <led-drivers/LedDevice.h>
+
+class DriverNetHomeAssistant : public LedDevice
+{
+	Q_OBJECT
+
+public:
+	explicit DriverNetHomeAssistant(const QJsonObject& deviceConfig);
+	static LedDevice* construct(const QJsonObject& deviceConfig);
+
+private:
+	bool init(const QJsonObject& deviceConfig) override;
+	int write(const std::vector<ColorRgb>& ledValues) override;
+
+	static bool isRegistered;
+};

--- a/sources/api/HyperAPI.cpp
+++ b/sources/api/HyperAPI.cpp
@@ -1294,7 +1294,7 @@ void HyperAPI::handleTunnel(const QJsonObject& message, const QString& command, 
 		const QString& data = message["data"].toString().trimmed();
 		const QString& service = message["service"].toString().trimmed();
 
-		if (service == "hue")
+		if (service == "hue" || service == "home_assistant")
 		{
 			QUrl tempUrl("http://"+ip);
 			if ((path.indexOf("/clip/v2") != 0 && path.indexOf("/api") != 0) || ip.indexOf("/") >= 0)
@@ -1305,7 +1305,7 @@ void HyperAPI::handleTunnel(const QJsonObject& message, const QString& command, 
 
 			ProviderRestApi provider;
 
-			QUrl url = QUrl((path.startsWith("/clip/v2") ? "https://" : "http://")+tempUrl.host()+path);
+			QUrl url = QUrl((path.startsWith("/clip/v2") ? "https://" : "http://")+tempUrl.host() + ((service == "home_assistant" && tempUrl.port() >= 0) ? ":" + QString::number(tempUrl.port()) : "") + path);
 
 			Debug(_log, "Tunnel request for: %s", QSTRING_CSTR(url.toString()));
 

--- a/sources/api/JSONRPC_schema/schema-tunnel.json
+++ b/sources/api/JSONRPC_schema/schema-tunnel.json
@@ -18,7 +18,7 @@
 		"service": {
 			"type" : "string",
 			"required" : true,
-			"enum" : ["hue"]
+			"enum" : ["hue", "home_assistant"]
 		},
 		"ip": {
 			"type" : "string",

--- a/sources/bonjour/BonjourServiceHelper.cpp
+++ b/sources/bonjour/BonjourServiceHelper.cpp
@@ -38,7 +38,8 @@ BonjourServiceHelper::BonjourServiceHelper(BonjourServiceRegister* parent, QStri
 	has_ipv6 = 0;
 	_scanService = (1 << DiscoveryRecord::Service::HyperHDR) |
 		(1 << DiscoveryRecord::Service::WLED) |
-		(1 << DiscoveryRecord::Service::PhilipsHue);
+		(1 << DiscoveryRecord::Service::PhilipsHue) |
+		(1 << DiscoveryRecord::Service::HomeAssistant);
 
 	_running = true;
 
@@ -506,7 +507,8 @@ int BonjourServiceHelper::service_mdns(QString hostname, QString serviceName, in
 		{
 			for (auto scanner :{ DiscoveryRecord::Service::HyperHDR,
 							DiscoveryRecord::Service::WLED,
-							DiscoveryRecord::Service::PhilipsHue })
+							DiscoveryRecord::Service::PhilipsHue,
+							DiscoveryRecord::Service::HomeAssistant })
 			{
 				if (_scanService & (1 << scanner))
 				{

--- a/sources/bonjour/BonjourServiceRegister.cpp
+++ b/sources/bonjour/BonjourServiceRegister.cpp
@@ -89,6 +89,7 @@ void BonjourServiceRegister::requestToScanHandler(DiscoveryRecord::Service type)
 		case (DiscoveryRecord::Service::HyperHDR): _helper->_scanService |= (1 << DiscoveryRecord::Service::HyperHDR); break;
 		case (DiscoveryRecord::Service::WLED): _helper->_scanService |= (1 << DiscoveryRecord::Service::WLED); break;
 		case (DiscoveryRecord::Service::PhilipsHue): _helper->_scanService |= (1 << DiscoveryRecord::Service::PhilipsHue); break;
+		case (DiscoveryRecord::Service::HomeAssistant): _helper->_scanService |= (1 << DiscoveryRecord::Service::HomeAssistant); break;
 		default: break;
 	}
 }
@@ -102,6 +103,8 @@ void BonjourServiceRegister::messageFromFriendHandler(bool isExists, QString mdn
 		type = DiscoveryRecord::Service::WLED;
 	else if (mdnsString.indexOf(DiscoveryRecord::getmDnsHeader(DiscoveryRecord::Service::PhilipsHue)) >= 0)
 		type = DiscoveryRecord::Service::PhilipsHue;
+	else if (mdnsString.indexOf(DiscoveryRecord::getmDnsHeader(DiscoveryRecord::Service::HomeAssistant)) >= 0)
+		type = DiscoveryRecord::Service::HomeAssistant;
 	else if (mdnsString.indexOf(DiscoveryRecord::getmDnsHeader(DiscoveryRecord::Service::HyperHDR)) >= 0)
 		type = DiscoveryRecord::Service::HyperHDR;
 

--- a/sources/bonjour/DiscoveryRecord.cpp
+++ b/sources/bonjour/DiscoveryRecord.cpp
@@ -33,6 +33,7 @@ const QString DiscoveryRecord::getmDnsHeader(Service service)
 	switch (service)
 	{
 		case(Service::PhilipsHue): return QLatin1String("_hue._tcp"); break;
+		case(Service::HomeAssistant): return QLatin1String("_home-assistant._tcp"); break;
 		case(Service::WLED): return QLatin1String("_wled._tcp"); break;
 		case(Service::HyperHDR): return QLatin1String("_hyperhdr-http._tcp"); break;
 		default: return "SERVICE_UNKNOWN";
@@ -49,6 +50,7 @@ const QString DiscoveryRecord::getName(Service _type)
 	switch (_type)
 	{
 		case(Service::PhilipsHue): return "Hue bridge"; break;
+		case(Service::HomeAssistant): return "Home Assistant"; break;
 		case(Service::WLED): return "WLED"; break;
 		case(Service::HyperHDR): return "HyperHDR"; break;
 		case(Service::Pico): return "Pico/RP2040"; break;

--- a/sources/bonjour/DiscoveryWrapper.cpp
+++ b/sources/bonjour/DiscoveryWrapper.cpp
@@ -88,6 +88,15 @@ QList<DiscoveryRecord> DiscoveryWrapper::getPhilipsHUE()
 	return _hueDevices;
 }
 
+QList<DiscoveryRecord> DiscoveryWrapper::getHomeAssistant()
+{
+	cleanUp(_homeAssistantDevices);
+
+	emit GlobalSignals::getInstance()->SignalDiscoveryRequestToScan(DiscoveryRecord::Service::HomeAssistant);
+
+	return _homeAssistantDevices;
+}
+
 QList<DiscoveryRecord> DiscoveryWrapper::getWLED()
 {
 	cleanUp(_wledDevices);
@@ -104,7 +113,7 @@ QList<DiscoveryRecord> DiscoveryWrapper::getHyperHDRServices()
 
 QList<DiscoveryRecord> DiscoveryWrapper::getAllServices()
 {
-	return _hyperhdrSessions + _esp32s2Devices + _espDevices + _hueDevices + _picoDevices + _wledDevices;
+	return _hyperhdrSessions + _esp32s2Devices + _espDevices + _hueDevices + _homeAssistantDevices + _picoDevices + _wledDevices;
 }
 
 void DiscoveryWrapper::requestServicesScan()
@@ -113,6 +122,8 @@ void DiscoveryWrapper::requestServicesScan()
 	emit GlobalSignals::getInstance()->SignalDiscoveryRequestToScan(DiscoveryRecord::Service::WLED);
 	cleanUp(_hueDevices);
 	emit GlobalSignals::getInstance()->SignalDiscoveryRequestToScan(DiscoveryRecord::Service::PhilipsHue);
+	cleanUp(_homeAssistantDevices);
+	emit GlobalSignals::getInstance()->SignalDiscoveryRequestToScan(DiscoveryRecord::Service::HomeAssistant);
 	cleanUp(_hyperhdrSessions);
 	emit GlobalSignals::getInstance()->SignalDiscoveryRequestToScan(DiscoveryRecord::Service::HyperHDR);
 
@@ -172,6 +183,8 @@ void DiscoveryWrapper::signalDiscoveryEventHandler(DiscoveryRecord message)
 		gotMessage(_wledDevices, message);
 	else if (message.type == DiscoveryRecord::Service::PhilipsHue)
 		gotMessage(_hueDevices, message);
+	else if (message.type == DiscoveryRecord::Service::HomeAssistant)
+		gotMessage(_homeAssistantDevices, message);
 	else if (message.type == DiscoveryRecord::Service::Pico)
 		gotMessage(_picoDevices, message);
 	else if (message.type == DiscoveryRecord::Service::ESP32_S2)

--- a/sources/led-drivers/CMakeLists.txt
+++ b/sources/led-drivers/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(led-drivers OBJECT ${Leddevice_SOURCES} )
 target_link_libraries(led-drivers
 	Qt${Qt_VERSION}::Core
 	Qt${Qt_VERSION}::Network
+	linalg
 )
 
 IF ( HAVE_SERIAL_LED )

--- a/sources/led-drivers/LedDeviceSchemas.qrc
+++ b/sources/led-drivers/LedDeviceSchemas.qrc
@@ -38,5 +38,6 @@
 		<file alias="schema-yeelight">schemas/schema-yeelight.json</file>
 		<file alias="schema-cololight">schemas/schema-cololight.json</file>
 		<file alias="schema-hyperspi">schemas/schema-hyperspi.json</file>
+		<file alias="schema-home_assistant">schemas/schema-home_assistant.json</file>
 	</qresource>
 </RCC>

--- a/sources/led-drivers/net/DriverNetHomeAssistant.cpp
+++ b/sources/led-drivers/net/DriverNetHomeAssistant.cpp
@@ -1,5 +1,10 @@
 #include <led-drivers/net/DriverNetHomeAssistant.h>
 
+#include <HyperhdrConfig.h>
+#ifdef ENABLE_BONJOUR
+	#include <bonjour/DiscoveryWrapper.h>
+#endif
+
 DriverNetHomeAssistant::DriverNetHomeAssistant(const QJsonObject& deviceConfig)
 	: LedDevice(deviceConfig)
 {
@@ -20,6 +25,38 @@ bool DriverNetHomeAssistant::init(const QJsonObject& deviceConfig)
 int DriverNetHomeAssistant::write(const std::vector<ColorRgb>& ledValues)
 {
 	return 0;
+}
+
+QJsonObject DriverNetHomeAssistant::discover(const QJsonObject& params)
+{
+	QJsonObject devicesDiscovered;
+	QJsonArray deviceList;
+	devicesDiscovered.insert("ledDeviceType", _activeDeviceType);
+
+#ifdef ENABLE_BONJOUR
+	std::shared_ptr<DiscoveryWrapper> bonInstance = _discoveryWrapper.lock();
+	if (bonInstance != nullptr)
+	{
+		QList<DiscoveryRecord> recs;
+
+		SAFE_CALL_0_RET(bonInstance.get(), getHomeAssistant, QList<DiscoveryRecord>, recs);
+
+		for (DiscoveryRecord& r : recs)
+		{
+			QJsonObject newIp;
+			newIp["value"] = QString("%1:8123").arg(r.address);
+			newIp["name"] = QString("%1 (%2)").arg(newIp["value"].toString()).arg(r.hostName);
+			deviceList.push_back(newIp);
+		}
+	}
+#else
+	Error(_log, "The Network Discovery Service was mysteriously disabled while the maintainer was compiling this version of HyperHDR");
+#endif	
+
+	devicesDiscovered.insert("devices", deviceList);
+	Debug(_log, "devicesDiscovered: [%s]", QString(QJsonDocument(devicesDiscovered).toJson(QJsonDocument::Compact)).toUtf8().constData());
+
+	return devicesDiscovered;
 }
 
 bool DriverNetHomeAssistant::isRegistered = hyperhdr::leds::REGISTER_LED_DEVICE("home_assistant", "leds_group_2_network", DriverNetHomeAssistant::construct);

--- a/sources/led-drivers/net/DriverNetHomeAssistant.cpp
+++ b/sources/led-drivers/net/DriverNetHomeAssistant.cpp
@@ -19,6 +19,37 @@ bool DriverNetHomeAssistant::init(const QJsonObject& deviceConfig)
 {
 	bool isInitOK = false;
 
+	if (LedDevice::init(deviceConfig))
+	{
+
+		_haInstance.homeAssistantHost = deviceConfig["homeAssistantHost"].toString();
+		_haInstance.longLivedAccessToken = deviceConfig["longLivedAccessToken"].toString();
+		_haInstance.restoreOriginalState = deviceConfig["restoreOriginalState"].toBool(false);
+		_maxRetry = deviceConfig["maxRetry"].toInt(60);
+
+		
+		Debug(_log, "HomeAssistantHost    : %s", QSTRING_CSTR(_haInstance.homeAssistantHost));
+		Debug(_log, "RestoreOriginalState : %s", _haInstance.restoreOriginalState ? "yes" : "no");
+		Debug(_log, "Max retry            : %d", _maxRetry);
+
+		auto arr = deviceConfig["lamps"].toArray();
+
+		for (const auto&& lamp : arr)
+			if (lamp.isObject())
+			{
+				HomeAssistantLamp hl;
+				auto lampObj = lamp.toObject();
+				hl.name = lampObj["name"].toString();
+				hl.colorModel = static_cast<HomeAssistantLamp::Mode>(lampObj["colorModel"].toInt(0));				
+				Debug(_log, "New lamp (%s)       : %s", (hl.colorModel == 0) ? "RGB" : "HSV", QSTRING_CSTR(hl.name));
+				_haInstance.lamps.push_back(hl);
+			}
+
+		if (_haInstance.homeAssistantHost.length() > 0 && _haInstance.longLivedAccessToken.length() > 0 && arr.size() > 0)
+		{
+			isInitOK = true;
+		}
+	}
 	return isInitOK;
 }
 

--- a/sources/led-drivers/net/DriverNetHomeAssistant.cpp
+++ b/sources/led-drivers/net/DriverNetHomeAssistant.cpp
@@ -82,7 +82,7 @@ bool DriverNetHomeAssistant::powerOnOff(bool isOn)
 	if (response.error())
 	{
 		this->setInError(response.error() ? response.getErrorReason() : "Unknown");
-		setupRetry(1500);
+		setupRetry(5000);
 		return false;
 	}
 
@@ -152,7 +152,14 @@ int DriverNetHomeAssistant::write(const std::vector<ColorRgb>& ledValues)
 			doc.setObject(row);
 			QString message(doc.toJson(QJsonDocument::Compact));
 			_restApi->setBasePath("/api/services/light/turn_on");
-			_restApi->post(message);
+			auto response = _restApi->post(message);
+
+			if (response.error())
+			{
+				this->setInError(response.error() ? response.getErrorReason() : "Unknown");
+				setupRetry(5000);
+				return false;
+			}
 		}
 
 	return 0;
@@ -167,7 +174,7 @@ bool DriverNetHomeAssistant::saveStates()
 		if (response.error())
 		{
 			this->setInError(response.error() ? response.getErrorReason() : "Unknown");
-			setupRetry(1500);
+			setupRetry(5000);
 			return false;
 		}
 		auto body = response.getBody();

--- a/sources/led-drivers/net/DriverNetHomeAssistant.cpp
+++ b/sources/led-drivers/net/DriverNetHomeAssistant.cpp
@@ -1,0 +1,25 @@
+#include <led-drivers/net/DriverNetHomeAssistant.h>
+
+DriverNetHomeAssistant::DriverNetHomeAssistant(const QJsonObject& deviceConfig)
+	: LedDevice(deviceConfig)
+{
+}
+
+LedDevice* DriverNetHomeAssistant::construct(const QJsonObject& deviceConfig)
+{
+	return new DriverNetHomeAssistant(deviceConfig);
+}
+
+bool DriverNetHomeAssistant::init(const QJsonObject& deviceConfig)
+{
+	bool isInitOK = false;
+
+	return isInitOK;
+}
+
+int DriverNetHomeAssistant::write(const std::vector<ColorRgb>& ledValues)
+{
+	return 0;
+}
+
+bool DriverNetHomeAssistant::isRegistered = hyperhdr::leds::REGISTER_LED_DEVICE("home_assistant", "leds_group_2_network", DriverNetHomeAssistant::construct);

--- a/sources/led-drivers/schemas/schema-home_assistant.json
+++ b/sources/led-drivers/schemas/schema-home_assistant.json
@@ -60,7 +60,15 @@
 							"enum_titles" : ["edt_conf_enum_rgb", "edt_conf_enum_hsv"]
 						},
 						"propertyOrder" : 2
-					}
+					},
+					"defaultPosition" :
+					{
+						"type": "string",
+						"options": {
+							"hidden": true
+						},
+						"propertyOrder" : 3
+					}					
 				}
 			}
 		}

--- a/sources/led-drivers/schemas/schema-home_assistant.json
+++ b/sources/led-drivers/schemas/schema-home_assistant.json
@@ -14,12 +14,31 @@
 			"required" : true,
 			"propertyOrder" : 2
 		},
+		"transition": {
+			"type": "integer",
+			"title": "edt_dev_spec_transistionTime_title",
+			"default": 0,
+			"append": "ms",
+			"minimum": 0,
+			"maximum": 3000,
+			"required": true,
+			"propertyOrder": 3
+		},
+		"constantBrightness": {
+			"type": "integer",
+			"title": "edt_dev_spec_constantBrightness_title",
+			"default": 0,
+			"minimum": 0,
+			"maximum": 255,
+			"required": true,
+			"propertyOrder": 4
+		},
 		"restoreOriginalState": {
 			"type": "boolean",
 			"format": "checkbox",
 			"title":"edt_dev_spec_restoreOriginalState_title",
 			"default" : false,
-			"propertyOrder" : 3
+			"propertyOrder" : 5
 		},
 		"maxRetry": {
 			"type" : "integer",
@@ -30,12 +49,12 @@
 			"maximum" : 300,
 			"default" : 60,
 			"required" : true,
-			"propertyOrder" : 4
+			"propertyOrder" : 6
 		},
 		"lamps": {
 			"type": "array",
 			"title":"edt_dev_spec_lights_title",
-			"propertyOrder" : 5,
+			"propertyOrder" : 6,
 			"uniqueItems" : true,
 			"items" : {
 				"type" : "object",

--- a/sources/led-drivers/schemas/schema-home_assistant.json
+++ b/sources/led-drivers/schemas/schema-home_assistant.json
@@ -54,7 +54,7 @@
 		"lamps": {
 			"type": "array",
 			"title":"edt_dev_spec_lights_title",
-			"propertyOrder" : 6,
+			"propertyOrder" : 7,
 			"uniqueItems" : true,
 			"items" : {
 				"type" : "object",

--- a/sources/led-drivers/schemas/schema-home_assistant.json
+++ b/sources/led-drivers/schemas/schema-home_assistant.json
@@ -1,0 +1,69 @@
+{
+	"type":"object",
+	"required":true,
+	"properties":{
+		"homeAssistantHost" : {
+			"type": "string",
+			"title":"edt_dev_spec_targetIpHost_title",
+			"required" : true,
+			"propertyOrder" : 1
+		},
+		"longLivedAccessToken" : {
+			"type": "string",
+			"title":"edt_dev_auth_key_title",
+			"required" : true,
+			"propertyOrder" : 2
+		},
+		"restoreOriginalState": {
+			"type": "boolean",
+			"format": "checkbox",
+			"title":"edt_dev_spec_restoreOriginalState_title",
+			"default" : false,
+			"propertyOrder" : 3
+		},
+		"maxRetry": {
+			"type" : "integer",
+			"format" : "stepper",			
+			"step"   : 1,			
+			"title" : "edt_dev_max_retry",
+			"minimum" : 0,
+			"maximum" : 300,
+			"default" : 60,
+			"required" : true,
+			"propertyOrder" : 4
+		},
+		"lamps": {
+			"type": "array",
+			"title":"edt_dev_spec_lights_title",
+			"propertyOrder" : 5,
+			"uniqueItems" : true,
+			"items" : {
+				"type" : "object",
+				"title" : "edt_dev_spec_lights_itemtitle",				
+				"required" : [
+					"name", "colorModel"
+				],
+				"properties" :
+				{						
+					"name" :
+					{
+						"type": "string",
+						"title" : "edt_dev_spec_lights_name",
+						"propertyOrder" : 1
+					},
+					"colorModel": {
+						"type": "integer",
+						"title":"edt_conf_bb_mode_title",
+						"enum" : [0, 1],
+						"default" : 0,
+						"options" : {
+							"enum_titles" : ["edt_conf_enum_rgb", "edt_conf_enum_hsv"]
+						},
+						"propertyOrder" : 2
+					}
+				}
+			}
+		}
+	},
+	"additionalProperties": true
+}

--- a/sources/led-drivers/schemas/schema-skydimo.json
+++ b/sources/led-drivers/schemas/schema-skydimo.json
@@ -11,7 +11,7 @@
 		"rate": {
 			"type": "integer",
 			"title":"edt_dev_spec_baudrate_title",
-			"default": 1000000,
+			"default": 115200,
 			"propertyOrder" : 2
 		},
 		"delayAfterConnect": {

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -1266,5 +1266,6 @@
   "edt_automatic_tone_mapping_disable_time_expl": "In an ideal world this value should be zero, because tone mapping should be disabled immediately after crossing one of the thresholds. But it happens, for example: when starting or switching resolution, the grabber can generate junk frames, which can disable tone mapping unnecessarily.",
   "wiz_home_assistant_title": "Home Assistant lights wizard",
   "wiz_ha_intro": "Please select the address of the Home Assistant instance and enter the 'Long Lived Access Tokens' created there.",
-  "select_ha_intro": "Select Home Assistant"
+  "select_ha_intro": "Select Home Assistant",
+  "edt_dev_spec_constantBrightness_title" : "Constant brightness"
 }

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -1263,5 +1263,8 @@
   "edt_automatic_tone_mapping_time_title": "Time to turn on tone mapping",
   "edt_automatic_tone_mapping_time_expl": "Time to turn on tone mapping if the signal does not exceed the configured threshold levels.",
   "edt_automatic_tone_mapping_disable_time_title": "Time to turn off tone mapping",
-  "edt_automatic_tone_mapping_disable_time_expl": "In an ideal world this value should be zero, because tone mapping should be disabled immediately after crossing one of the thresholds. But it happens, for example: when starting or switching resolution, the grabber can generate junk frames, which can disable tone mapping unnecessarily."
+  "edt_automatic_tone_mapping_disable_time_expl": "In an ideal world this value should be zero, because tone mapping should be disabled immediately after crossing one of the thresholds. But it happens, for example: when starting or switching resolution, the grabber can generate junk frames, which can disable tone mapping unnecessarily.",
+  "wiz_home_assistant_title": "Home Assistant lights wizard",
+  "wiz_ha_intro": "Please select the address of the Home Assistant instance and enter the 'Long Lived Access Tokens' created there.",
+  "select_ha_intro": "Select Home Assistant"
 }

--- a/www/js/hyperhdr.js
+++ b/www/js/hyperhdr.js
@@ -662,3 +662,23 @@ async function requestHasLedClock()
 {
 	sendToHyperhdr("leddevice", "hasLedClock", `"ledDeviceType": "", "params": {}`, Math.floor(Math.random() * 1000));
 }
+
+async function tunnel_home_assistant_get(_ip, _path,header={})
+{
+	let data = { service: "home_assistant", ip: _ip, path: _path, data: "", header };
+	let r = await sendAsyncToHyperhdr("tunnel", "get", data, Math.floor(Math.random() * 1000));
+	if (r["success"] != true || r["isTunnelOk"] != true)
+		return null;
+	else
+		return r["info"];
+}
+
+async function tunnel_home_assistant_post(_ip, _path, header={}, _data)
+{
+	let data = { service: "home_assistant", ip: _ip, path: _path, data: _data, header };
+	let r = await sendAsyncToHyperhdr("tunnel", "post", data, Math.floor(Math.random() * 1000));
+	if (r["success"] != true || r["isTunnelOk"] != true)
+		return null;
+	else
+		return r["info"];
+}

--- a/www/js/light_source.js
+++ b/www/js/light_source.js
@@ -26,6 +26,42 @@ if (typeof ResizeObserver === "function" && _resizeObserver === null)
 	});	
 }
 
+async function deviceListRefresh(ledTypeTarget, discoveryResult, targetDiscoveryEditor, targetDiscoveryFirstLabel, targetDiscoverySecondLabel = 'main_menu_update_token')
+{
+	let receiver = $("#deviceListInstances");
+	receiver.off();
+	receiver.empty();
+
+	$("<option />", {value: "", text: $.i18n(targetDiscoveryFirstLabel)}).appendTo(receiver);
+
+	if (discoveryResult.info != null && discoveryResult.info.devices != null)
+	{					
+		(discoveryResult.info.devices).forEach(function (val) {
+			$("<option />", {value: val.value, text: val.name}).appendTo(receiver);
+		});
+	}
+		
+	$("<option />", {value: -1, text: $.i18n(targetDiscoverySecondLabel)}).appendTo(receiver);
+
+	receiver.on('change', function ()
+	{
+		let selVal = $("#deviceListInstances").val();
+		if (selVal == -1)			
+			requestLedDeviceDiscovery(ledTypeTarget).then( (newResult) => deviceListRefresh(ledTypeTarget, newResult, targetDiscoveryEditor, targetDiscoveryFirstLabel, targetDiscoverySecondLabel));
+		else if (selVal != "")
+		{
+			if (typeof targetDiscoveryEditor === 'string' || targetDiscoveryEditor instanceof String)
+			{
+				conf_editor.getEditor(targetDiscoveryEditor).setValue(selVal);
+			}
+			else
+			{
+				targetDiscoveryEditor.val(selVal).change();
+			}
+		}
+	});			
+}
+
 function createLedPreview(leds, origin)
 {
 	_lastLeds = leds;
@@ -574,34 +610,7 @@ $(document).ready(function()
 			$('#ip_ma_' + key).prop('checked', slConfig.matrix[key]);
 		else
 			$('#ip_ma_' + key).val(slConfig.matrix[key]);
-	}
-
-	async function deviceListRefresh(ledTypeTarget, discoveryResult, targetDiscoveryEditor, targetDiscoveryFirstLabel, targetDiscoverySecondLabel = 'main_menu_update_token')
-	{
-		let receiver = $("#deviceListInstances");
-		receiver.off();
-		receiver.empty();
-
-		$("<option />", {value: "", text: $.i18n(targetDiscoveryFirstLabel)}).appendTo(receiver);
-
-		if (discoveryResult.info != null && discoveryResult.info.devices != null)
-		{					
-			(discoveryResult.info.devices).forEach(function (val) {
-				$("<option />", {value: val.value, text: val.name}).appendTo(receiver);
-			});
-		}
-		
-		$("<option />", {value: -1, text: $.i18n(targetDiscoverySecondLabel)}).appendTo(receiver);
-
-		receiver.on('change', function ()
-		{
-			let selVal = $("#deviceListInstances").val();
-			if (selVal == -1)			
-				requestLedDeviceDiscovery(ledTypeTarget).then( (newResult) => deviceListRefresh(ledTypeTarget, newResult, targetDiscoveryEditor, targetDiscoveryFirstLabel, targetDiscoverySecondLabel));
-			else if (selVal != "")
-				conf_editor.getEditor(targetDiscoveryEditor).setValue(selVal);
-		});			
-	}
+	}	
 
 	function saveValues()
 	{
@@ -859,7 +868,7 @@ $(document).ready(function()
 			});
 			$("input[name='root[specificOptions][useEntertainmentAPI]']").trigger("change");
 		}
-		else if ([ "cololight", "yeelight", "atmoorb"].includes(ledType))
+		else if ([ "cololight", "yeelight", "atmoorb", "home_assistant"].includes(ledType))
 		{
 			const data = {
 				type: ledType

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -2494,7 +2494,8 @@ function startWizardHome_assistant(e)
 		haConfig.type = 'home_assistant';	
 		haConfig.colorOrder = conf_editor.getEditor("root.generalOptions.colorOrder").getValue();
 		haConfig.homeAssistantHost = $('#hostHA').val().trim();
-		haConfig.longLivedAccessToken = $('#tokenHA').val().trim();
+		haConfig.longLivedAccessToken= $('#tokenHA').val().trim();
+		haConfig.transition = conf_editor.getEditor("root.specificOptions.transition").getValue();
 		haConfig.restoreOriginalState = conf_editor.getEditor("root.specificOptions.restoreOriginalState").getValue();
 		haConfig.maxRetry = conf_editor.getEditor("root.specificOptions.maxRetry").getValue();
 		haConfig.lamps = [];		

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -2453,3 +2453,38 @@ async function discover_providerHid(hidType)
 		console.log(r);
 	}
 }
+
+//****************************
+// Wizard Home-Assistant
+//****************************
+
+function startWizardHome_assistant(e)
+{
+	$('#wiz_header').html(`<svg data-src="svg/wizard.svg" fill="currentColor" class="svg4hyperhdr"></svg>${$.i18n('wiz_home_assistant_title')}`);
+	$('#wizp1_body').html(`<h4 style="font-weight:bold;text-transform:uppercase;">${$.i18n('wiz_home_assistant_title')}</h4><p>${$.i18n('wiz_ha_intro')}</p><div class="form-group" id="ha_form"></div>`);
+	$('#wizp1_footer').html(`<button type="button" class="btn btn-primary" id="btn_wiz_cont" disabled><svg data-src="svg/button_play.svg" fill="currentColor" class="svg4hyperhdr"></svg>${$.i18n('general_btn_continue')}</button><button type="button" class="btn btn-danger" data-bs-dismiss="modal"><svg data-src="svg/button_close.svg" fill="currentColor" class="svg4hyperhdr"></svg>${$.i18n('general_btn_cancel')}</button>`);
+
+	$('#ha_form').append(`<label for="hostHA" class="form-label">${$.i18n('device_address')}</label><div><input type="text" id="hostHA" name="haInputParams1" class="form-control float-left d-inline" style="width:52%"/><select id="deviceListInstances" class="form-select bg-warning float-left d-inline" style="width:46%" /></div>`);
+	$('#ha_form').append(`<label for="tokenHA" class="form-label mt-4">${$.i18n('edt_dev_auth_key_title')}</label><input type="text" id="tokenHA" name="haInputParams2" class="form-control">`);
+
+	requestLedDeviceDiscovery('home_assistant').then( (result) => deviceListRefresh('home_assistant', result, $('#hostHA'),'select_ha_intro','main_menu_update_token'));
+
+	let haForm = new bootstrap.Modal($("#wizard_modal"), {
+		backdrop: "static",
+		keyboard: false
+	});
+
+	$('input[name^=haInputParams]').on('change input',function(e){		
+		if ($('#hostHA').val().length > 0 && $('#tokenHA').val().length > 0)
+		{
+			$("#btn_wiz_cont").prop('disabled', false);
+		}
+	});
+
+	haForm.show();
+
+	$('#btn_wiz_cont').off().on('click', function ()
+	{
+		resetWizard();
+	});
+}

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -2458,6 +2458,7 @@ async function discover_providerHid(hidType)
 // Wizard Home-Assistant
 //****************************
 
+
 function startWizardHome_assistant(e)
 {
 	$('#wiz_header').html(`<svg data-src="svg/wizard.svg" fill="currentColor" class="svg4hyperhdr"></svg>${$.i18n('wiz_home_assistant_title')}`);
@@ -2481,10 +2482,160 @@ function startWizardHome_assistant(e)
 		}
 	});
 
+	$('#hostHA').val(conf_editor.getEditor("root.specificOptions.homeAssistantHost").getValue());
+	$('#tokenHA').val(conf_editor.getEditor("root.specificOptions.longLivedAccessToken").getValue()).change();
+
 	haForm.show();
 
 	$('#btn_wiz_cont').off().on('click', function ()
 	{
+		let haConfig = {};
+					
+		haConfig.type = 'home_assistant';	
+		haConfig.colorOrder = conf_editor.getEditor("root.generalOptions.colorOrder").getValue();
+		haConfig.homeAssistantHost = $('#hostHA').val().trim();
+		haConfig.longLivedAccessToken = $('#tokenHA').val().trim();
+		haConfig.restoreOriginalState = conf_editor.getEditor("root.specificOptions.restoreOriginalState").getValue();
+		haConfig.maxRetry = conf_editor.getEditor("root.specificOptions.maxRetry").getValue();
+		haConfig.lamps = [];		
+
+		tunnel_home_assistant_get(haConfig.homeAssistantHost, '/api/states',{'Authorization':`Bearer ${haConfig.longLivedAccessToken}` }).then( (r) =>
+			{
+				if (r != null && Array.isArray(r))
+				{
+					r.forEach((entity) => {
+						if (typeof (entity) === 'object' && entity["entity_id"] != null)
+						{
+							const attributes = entity["attributes"];
+							if ( attributes != null && typeof (attributes) === 'object')
+							{
+								const supported_color_modes = attributes["supported_color_modes"];
+								if ( supported_color_modes != null && Array.isArray(supported_color_modes) && supported_color_modes.length > 0)
+								{
+									let colorMode = null;
+									supported_color_modes.forEach((capability) => {
+										if (capability === "xy")
+										{
+											colorMode = "rgb";
+										}
+										else if (capability === "hs")
+										{
+											colorMode = "hsv";
+										}										
+									});
+									if (colorMode != null)
+									{
+										var lamp = {};
+										lamp.name = entity["entity_id"];
+										lamp.colorModel = colorMode;
+										haConfig.lamps.push(lamp);
+									}
+								}
+							}
+						}
+					});
+
+					if (window.serverConfig.device != null && window.serverConfig.device.type == haConfig.type &&
+					   Array.isArray(window.serverConfig.device.lamps) && window.serverConfig.device.lamps.length ==  haConfig.lamps.length)
+					{
+						for (var key in haConfig.lamps)
+						if (haConfig.lamps[key].name =  window.serverConfig.device.lamps[key].name)
+						{
+							haConfig.lamps[key].defaultPosition = window.serverConfig.device.lamps[key].defaultPosition;
+						}
+					}
+
+					window.serverConfig.device = haConfig;
+					requestWriteConfig({ "device": window.serverConfig.device });
+					createHaLedConfig(haConfig);
+				}
+				else
+				{
+					showNotification('danger', $.i18n('wiz_hue_e_title'), $.i18n('wiz_hue_e_noapisupport_hint'));
+				}
+			}
+		);		
+	});
+}
+
+function identify_ha_device(host, token, id)
+{
+	const address = host;
+	const bearerToken = token;
+	const deviceId = `{"entity_id": "${id}"}`;
+	tunnel_home_assistant_post(address, '/api/services/light/turn_off', {'Authorization':`Bearer ${bearerToken}` }, deviceId).then(() =>
+		{
+			new Promise((resolve) => setTimeout(resolve, 1000)).then((r) =>
+				{
+					tunnel_home_assistant_post(address, '/api/services/light/turn_on', {'Authorization':`Bearer ${bearerToken}` }, deviceId);
+				});			
+		}
+	);
+}
+
+function createHaLedConfig(haConfig)
+{
+	var lightOptions = [
+		"top", "topleft", "topright",
+		"bottom", "bottomleft", "bottomright",
+		"left", "lefttop", "leftmiddle", "leftbottom",
+		"right", "righttop", "rightmiddle", "rightbottom",
+		"entire",
+		"lightPosBottomLeft14", "lightPosBottomLeft12", "lightPosBottomLeft34", "lightPosBottomLeft11",
+		"lightPosBottomLeft112", "lightPosBottomLeftNewMid", "lightPosBottomLeft121",
+		"lightPosTopLeft112", "lightPosTopLeftNewMid", "lightPosTopLeft121"
+	];
+
+	$('#wizp2_body').html('<div id="wh_topcontainer"></div>');
+	$('#wizp2_body').append(`<div id="ha_lamps_table_holder"><p style="font-weight:bold">${$.i18n('wiz_hue_e_desc3')}</p></div>`);
+	$('#wizp2_footer').html(`<button type="button" class="btn btn-primary" id="btn_wiz_save"><svg data-src="svg/button_save.svg" fill="currentColor" class="svg4hyperhdr"></svg>${$.i18n('general_btn_save')}</button><button type="button" class="btn btn-danger" id="btn_wiz_abort" disabled><svg data-src="svg/button_close.svg" fill="currentColor" class="svg4hyperhdr"></svg>${$.i18n('general_btn_cancel')}</button>`);
+
+	if (window.serverConfig.leds != null && window.serverConfig.leds.length == haConfig.lamps.length)
+	{
+		$("#btn_wiz_abort").prop('disabled', false);
+	}
+
+	$('#btn_wiz_abort').off().on('click', function () { resetWizard(); });
+	const _haConfig = haConfig;
+	$('#btn_wiz_save').off().on('click', function () {
+		let ledDef = [];
+		for (var key in _haConfig.lamps)
+		{
+			var defaultPosition = $('#ha_lamp_pos_' + key).val();			
+			var idx_content = assignLightPos(key, defaultPosition, _haConfig.lamps[key].name);
+
+			_haConfig.lamps[key].defaultPosition = defaultPosition;
+			ledDef.push(JSON.parse(JSON.stringify(idx_content)));
+		}
+		window.serverConfig.leds = ledDef;
+		requestWriteConfig({ "leds": window.serverConfig.leds });
+		window.serverConfig.device = _haConfig;
+		requestWriteConfig({ "device": window.serverConfig.device });
 		resetWizard();
 	});
+
+	createTableFlex("ha_lamps_table_header", "ha_lamps_rows", "ha_lamps_table_holder");
+	$('.ha_lamps_table_header').append(createTableRowFlex([$.i18n('edt_dev_spec_lightid_title'), $.i18n('wiz_pos'), $.i18n('wiz_identify')], true));
+	$('.ha_lamps_rows').html("");
+
+	var ledHaIndex = 0;
+	haConfig.lamps.forEach((lamp) => {
+		let options = "";
+		for (var opt in lightOptions)
+		{
+			var val = lightOptions[opt];
+			var txt = (val != 'entire' && val != 'disabled') ? 'conf_leds_layout_cl_' : 'wiz_ids_';
+			options += `<option value="${val}" ${(lamp.defaultPosition === val) ? "selected" : "" } >${$.i18n(txt + val)}</option>`;
+		}
+		let selectLightControl = `<select id="ha_lamp_pos_${ledHaIndex}" class="hue_sel_watch form-select">${options}</select>`;
+		let ipVal = encodeURI(haConfig.homeAssistantHost);
+		let tokenVal = haConfig.longLivedAccessToken;					
+		let buttonLightLink = `<button class="btn btn-sm btn-primary" onClick=identify_ha_device("${ipVal}","${tokenVal}","${lamp.name}")>${$.i18n('wiz_identify_light', ledHaIndex)}</button>`;					
+		$('.ha_lamps_rows').append(createTableRowFlex([lamp.name, selectLightControl, buttonLightLink]));
+		ledHaIndex++;
+	});
+
+	$('#wizp1').toggle(false);
+	$("#wizard_modal").addClass("modal-lg");
+	$('#wizp2').toggle(true);
 }

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -2514,7 +2514,7 @@ function startWizardHome_assistant(e)
 								{
 									let colorMode = null;
 									supported_color_modes.forEach((capability) => {
-										if (capability === "xy")
+										if (capability === "xy" || capability === "rgb")
 										{
 											colorMode = "rgb";
 										}


### PR DESCRIPTION
Work is finished:
- Added mDNS scan for HomeAssistant instances
- Web wizards including scanning of devices & lamps capabilities
- Support for dynamic and constant brightness
- Support for RGB and HSL model
- Support for saving & restoring state of lamps

Implements #918 

## Home Assistant configuration
I assume you've already configured your lights in Home Assistant. The photo below shows Philips Hue lights connected via a ZigBee adapter.

<a href="https://github.com/user-attachments/assets/53de8fa8-67dd-4989-bc8e-784697b09650"><img src="https://github.com/user-attachments/assets/53de8fa8-67dd-4989-bc8e-784697b09650" width="80%" /></a><br/>

If the lights work properly in Home Assistant, you need to create one more thing necessary to support them in HyperHDR: `Long Lived Access Token`.
You will find the required option in the Home Assistant user security settings as in the screenshot below.
You must copy it immediately when creating and save it.

<a href="https://github.com/user-attachments/assets/73866d9d-4957-4986-9a8b-b5c3deddbdc4"><img src="https://github.com/user-attachments/assets/73866d9d-4957-4986-9a8b-b5c3deddbdc4" width="80%" /></a><br/>

## HyperHDR configuration

Open HyperHDR and go to LED Hardware. Select "Home Assistant" from the tab and then click the button to launch the configuration wizard.

<a href="https://github.com/user-attachments/assets/c2f858ad-6e48-4d08-a7de-349da2aef431"><img src="https://github.com/user-attachments/assets/c2f858ad-6e48-4d08-a7de-349da2aef431" width="80%" /></a><br/>

By clicking the `Select Home Assistant` button you can see the list of instances that HyperHDR has found and choose the one you are interested in. Then below you need to enter the `Long Lived Access Token` that you created earlier in Home Assistant. When finished click the `Continue` button.

<a href="https://github.com/user-attachments/assets/3e262c10-ebd9-4329-81a4-71c9893c968f"><img src="https://github.com/user-attachments/assets/3e262c10-ebd9-4329-81a4-71c9893c968f" width="80%" /></a><br/>

On the next page HyperHDR will display all the supported lights it found in the Home Assistant instance. Now you can assign them a default position to the screen and intuit each of them (it will be turned off and on) so you can see which lamp you are configuring. You can always fix this configuration later in the LED layout editor. When you are done, save your changes.

<a href="https://github.com/user-attachments/assets/688d20cb-5609-4067-ab07-884563be8e42"><img src="https://github.com/user-attachments/assets/688d20cb-5609-4067-ab07-884563be8e42" width="80%" /></a><br/>

Congratulations! That's all. In the options you can also:

- choose between the RGB or HSL model. Each of them behaves slightly differently and it also depends on the lamp model how/whether it supports it or not

- set `transition time` which will provide smoother color transitions at the expense of delay

- by default `brightness` is dynamic and depends on the brightness of the selected color. However, you can change it and force it to be fixed

- if you want HyperHDR to restore to the original state it found at startup when turned off, check the option: restore default state