### PR TITLE
Windows: suspend & power off handling

### DIFF
--- a/include/systray/Systray.h
+++ b/include/systray/Systray.h
@@ -72,6 +72,7 @@ struct SystrayMenu
 
 #ifdef _WIN32
 	HWND SystrayGetWindow();
+	void SystrayAssignQueueHandler(std::function<void(WPARAM wparam)> _queueHandler);
 #endif
 
 

--- a/sources/suspend-handler/SuspendHandlerWindows.cpp
+++ b/sources/suspend-handler/SuspendHandlerWindows.cpp
@@ -38,6 +38,7 @@
 #include <windows.h>
 #include <wtsapi32.h>
 #include <systray/Systray.h>
+#include <QCoreApplication>
 
 #pragma comment (lib, "WtsApi32.Lib")
 
@@ -49,7 +50,12 @@ namespace
 
 static void SuspendHandlerQueueHandler(WPARAM wparam)
 {
-	if (instance != nullptr)
+	if (wparam == 0)
+	{
+		auto instance = QCoreApplication::instance();
+		QUEUE_CALL_0(instance, quit);
+	}
+	else if (instance != nullptr)
 	{
 		MSG message{};
 		QByteArray eventType;

--- a/sources/systray/SystrayWindows.cpp
+++ b/sources/systray/SystrayWindows.cpp
@@ -71,6 +71,13 @@ static LRESULT CALLBACK _tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wparam,
 			}
 			return true;
 
+		case WM_QUERYENDSESSION:
+			if (queueHandler != nullptr && lparam == 0)
+			{
+				queueHandler(0);
+			}
+			return false;
+
 		case WM_CLOSE:
 			DestroyWindow(hwnd);
 			hwnd = nullptr;

--- a/sources/systray/SystrayWindows.cpp
+++ b/sources/systray/SystrayWindows.cpp
@@ -46,6 +46,7 @@ namespace
 	std::list<HICON> icons;
 	std::list<HBITMAP> bitmaps;
 	ULONG_PTR gdiToken = 0;
+	std::function<void(WPARAM suspend)> queueHandler = nullptr;
 }
 
 HWND SystrayGetWindow()
@@ -53,11 +54,23 @@ HWND SystrayGetWindow()
 	return window;
 }
 
+void SystrayAssignQueueHandler(std::function<void(WPARAM wparam)> _queueHandler)
+{
+	queueHandler = _queueHandler;
+}
+
 static LRESULT CALLBACK _tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wparam,
                                        LPARAM lparam)
 {
 	switch (msg)
 	{
+		case WM_POWERBROADCAST:
+			if (queueHandler != nullptr && (wparam == PBT_APMSUSPEND || wparam == PBT_APMRESUMESUSPEND || wparam == PBT_POWERSETTINGCHANGE))
+			{				
+				queueHandler(wparam);
+			}
+			return true;
+
 		case WM_CLOSE:
 			DestroyWindow(hwnd);
 			hwnd = nullptr;
@@ -290,6 +303,8 @@ void SystrayUpdate(SystrayMenu *tray)
 
 void SystrayClose()
 {
+	queueHandler = nullptr;
+
 	if (systrayIcon.hIcon != nullptr)
 	{
 		Shell_NotifyIcon(NIM_DELETE, &systrayIcon);


### PR DESCRIPTION
The LEDs continue to light when the computer is turned off or put into sleep mode.
This PR fixes #1038 