### PR TITLE
Switch to Github Arm runners

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -18,58 +18,72 @@ jobs:
 
   Linux:
     name: ${{ matrix.dockerName }}
-    runs-on: ubuntu-22.04
-
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        linuxVersion: [ bullseye ]
-        dockerImage: [ x86_64, arm-32bit-armv6l, arm-64bit-aarch64 ]
-        include:        
-          - dockerImage: x86_64
+        include:
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: bullseye
             dockerName: Debian Bullseye (x86_64)
             platform: linux
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: bookworm
             dockerName: Debian Bookworm (x86_64)
             platform: linux
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: jammy
             dockerName: Ubuntu 22.04 LTS (x86_64)
             platform: linux
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: noble
             dockerName: Ubuntu 24.04 LTS (x86_64)
             platform: linux
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: oracular
             dockerName: Ubuntu 24.10 (x86_64)
-            platform: linux               
-          - dockerImage: arm-32bit-armv6l
-            linuxVersion: bullseye
-            dockerName: Debian Bullseye (ARM 32-bit Raspberry Pi OS)
-            platform: rpi
-          - dockerImage: arm-64bit-aarch64
-            linuxVersion: bullseye
-            dockerName: Debian Bullseye (ARM 64-bit Raspberry Pi OS)
-            platform: rpi
-          - dockerImage: arm-32bit-armv6l
-            linuxVersion: bookworm
-            dockerName: Debian Bookworm (ARM 32-bit Raspberry Pi OS)
-            platform: rpi
-          - dockerImage: arm-64bit-aarch64
-            linuxVersion: bookworm
-            dockerName: Debian Bookworm (ARM 64-bit Raspberry Pi OS)
-            platform: rpi              
-          - dockerImage: x86_64
+            platform: linux
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: Fedora_41
             dockerName: Fedora 41 (x86_64)
             platform: linux
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: ArchLinux
             dockerName: Arch Linux (x86_64)
             platform: linux
+          - runner: ubuntu-24.04-arm
+            dockerImage: arm-32bit-armv6l-native
+            linuxVersion: bullseye
+            dockerName: Debian Bullseye (native ARM 32-bit Raspberry Pi OS)
+            platform: rpi
+          - runner: ubuntu-24.04-arm
+            dockerImage: arm-64bit-aarch64-native
+            linuxVersion: bullseye
+            dockerName: Debian Bullseye (native ARM 64-bit Raspberry Pi OS)
+            platform: rpi
+          - runner: ubuntu-24.04-arm
+            dockerImage: arm-32bit-armv6l-native
+            linuxVersion: bookworm
+            dockerName: Debian Bookworm (native ARM 32-bit Raspberry Pi OS)
+            platform: rpi
+          - runner: ubuntu-24.04-arm
+            dockerImage: arm-64bit-aarch64-native
+            linuxVersion: bookworm
+            dockerName: Debian Bookworm (native ARM 64-bit Raspberry Pi OS)
+            platform: rpi
     steps:
+      # start docker
+      - name: Wake-up docker
+        if: matrix.runner == 'ubuntu-24.04-arm'
+        run: |
+          sudo systemctl start docker
+
       # checkout
       - uses: actions/checkout@v4.2.2
         with:
@@ -326,7 +340,7 @@ jobs:
 
   analyze:
     name: Analyze (CodeQL)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ vars.USE_CODEQL == 'true' && vars.USE_CODEQL || false }}
 
     permissions:

--- a/.github/workflows/upload-to-github-pages.yml
+++ b/.github/workflows/upload-to-github-pages.yml
@@ -15,7 +15,7 @@ jobs:
 ######################################
   Linux:
     name: ${{ matrix.niceName }} ${{ matrix.linuxVersion }} (${{ matrix.arch }})
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
@@ -23,43 +23,51 @@ jobs:
         linuxVersion: [ bullseye, bookworm ]
         dockerImage: [ x86_64, arm-32bit-armv6l, arm-64bit-aarch64 ]
         include:        
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             dockerName: Debian (amd64)
             arch: amd64
             platform: linux
-          - dockerImage: arm-32bit-armv6l
+          - runner: ubuntu-24.04-arm
+            dockerImage: arm-32bit-armv6l-native
             dockerName: Debian (armhf)
             arch: armhf
             platform: rpi
-          - dockerImage: arm-64bit-aarch64
+          - runner: ubuntu-24.04-arm
+            dockerImage: arm-64bit-aarch64-native
             dockerName: Debian (arm64)
             arch: arm64
             platform: rpi   
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: ArchLinux
             dockerName: Arch Linux (x86_64)
             arch: amd64
             platform: linux
             niceName: ""
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: jammy
             dockerName: Ubuntu 22.04 LTS (x86_64)
             arch: amd64
             platform: linux
             niceName: Ubuntu 22.04 LTS
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: noble
             dockerName: Ubuntu 24.04 LTS (x86_64)
             arch: amd64
             platform: linux
             niceName: Ubuntu 24.04 LTS           
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: oracular
             dockerName: Ubuntu 24.10 (x86_64)
             arch: amd64
             platform: linux
             niceName: Ubuntu 24.10
-          - dockerImage: x86_64
+          - runner: ubuntu-24.04
+            dockerImage: x86_64
             linuxVersion: Fedora_41
             dockerName: Fedora 41 (x86_64)
             arch: amd64
@@ -67,6 +75,12 @@ jobs:
             niceName: Fedora 41
 
     steps:
+      # start docker
+      - name: Wake-up docker
+        if: matrix.runner == 'ubuntu-24.04-arm'
+        run: |
+          sudo systemctl start docker
+    
       # checkout
       - uses: actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
Switch qemu arm runners to native arm runners.
Finally Github allows us to use them!  https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/