### PR TITLE
Updated Home Assistant module to enable SSL.

### DIFF
--- a/include/led-drivers/net/DriverNetHomeAssistant.h
+++ b/include/led-drivers/net/DriverNetHomeAssistant.h
@@ -20,6 +20,9 @@ class DriverNetHomeAssistant : public LedDevice
 	struct HomeAssistantInstance
 	{
 		QString homeAssistantHost;
+		int homeAssistantPort;
+                bool useSSL;
+
 		QString longLivedAccessToken;
 		int transition;
 		int constantBrightness = 255;

--- a/include/led-drivers/net/ProviderRestApi.h
+++ b/include/led-drivers/net/ProviderRestApi.h
@@ -25,6 +25,8 @@ public:
 	ProviderRestApi();
 	ProviderRestApi(const QString& host, int port);
 	ProviderRestApi(const QString& host, int port, const QString& basePath);
+	ProviderRestApi(const QString& host, int port, bool useSSL);
+	ProviderRestApi(const QString& host, int port, const QString& basePath, bool useSSL);
 	~ProviderRestApi();
 
 	void  updateHost(const QString& host, int port);

--- a/sources/led-drivers/net/DriverNetHomeAssistant.cpp
+++ b/sources/led-drivers/net/DriverNetHomeAssistant.cpp
@@ -25,16 +25,18 @@ bool DriverNetHomeAssistant::init(const QJsonObject& deviceConfig)
 	{
 
 		_haInstance.homeAssistantHost = deviceConfig["homeAssistantHost"].toString();
+		_haInstance.homeAssistantPort = deviceConfig["homeAssistantPort"].toInt(8123);
+		_haInstance.useSSL = deviceConfig["useSSL"].toBool(false);
 		_haInstance.longLivedAccessToken = deviceConfig["longLivedAccessToken"].toString();
 		_haInstance.transition = deviceConfig["transition"].toInt(0);
 		_haInstance.constantBrightness = deviceConfig["constantBrightness"].toInt(255);
 		_haInstance.restoreOriginalState = deviceConfig["restoreOriginalState"].toBool(false);
 		_maxRetry = deviceConfig["maxRetry"].toInt(60);
 
-		QUrl url("http://" + _haInstance.homeAssistantHost);
-		_restApi = std::make_unique<ProviderRestApi>(url.host(), url.port(8123));		
+		//QUrl url(_haInstance.homeAssistantHost);
+		_restApi = std::make_unique<ProviderRestApi>(_haInstance.homeAssistantHost, _haInstance.homeAssistantPort, _haInstance.useSSL);
 		_restApi->addHeader("Authorization", QString("Bearer %1").arg(_haInstance.longLivedAccessToken));
-		
+
 		Debug(_log, "HomeAssistantHost     : %s", QSTRING_CSTR(_haInstance.homeAssistantHost));
 		Debug(_log, "RestoreOriginalState  : %s", (_haInstance.restoreOriginalState) ? "yes" : "no");
 		Debug(_log, "Transition (ms)       : %s", (_haInstance.transition > 0) ? QSTRING_CSTR(QString::number(_haInstance.transition)) : "disabled" );
@@ -49,7 +51,7 @@ bool DriverNetHomeAssistant::init(const QJsonObject& deviceConfig)
 				HomeAssistantLamp hl;
 				auto lampObj = lamp.toObject();
 				hl.name = lampObj["name"].toString();
-				hl.colorModel = static_cast<HomeAssistantLamp::Mode>(lampObj["colorModel"].toInt(0));				
+				hl.colorModel = static_cast<HomeAssistantLamp::Mode>(lampObj["colorModel"].toInt(0));
 				hl.currentBrightness = _haInstance.constantBrightness;
 				Debug(_log, "Configured lamp (%s) : %s", (hl.colorModel == 0) ? "RGB" : "HSV", QSTRING_CSTR(hl.name));
 				_haInstance.lamps.push_back(hl);

--- a/sources/led-drivers/net/ProviderRestApi.cpp
+++ b/sources/led-drivers/net/ProviderRestApi.cpp
@@ -42,9 +42,9 @@
 
 const int TIMEOUT = (500);
 
-ProviderRestApi::ProviderRestApi(const QString& host, int port, const QString& basePath)
+ProviderRestApi::ProviderRestApi(const QString& host, int port, const QString& basePath, bool useSSL = false)
 	:_log(Logger::getInstance("LEDDEVICE"))
-	, _scheme((port == 443) ? "https" : "http")
+	, _scheme(useSSL ? "https" : "http")
 	, _hostname(host)
 	, _port(port)
 {
@@ -60,11 +60,14 @@ ProviderRestApi::ProviderRestApi(const QString& host, int port, const QString& b
 	_workerThread = NetworkHelper::threadFactory();
 }
 
+ProviderRestApi::ProviderRestApi(const QString& host, int port, bool useSSL = false)
+        : ProviderRestApi(host, port, "", useSSL) {}
+
 ProviderRestApi::ProviderRestApi(const QString& host, int port)
-	: ProviderRestApi(host, port, "") {}
+	: ProviderRestApi(host, port, "", false) {}
 
 ProviderRestApi::ProviderRestApi()
-	: ProviderRestApi("", -1) {}
+	: ProviderRestApi("", -1, "", false) {}
 
 ProviderRestApi::~ProviderRestApi()
 {

--- a/sources/led-drivers/schemas/schema-home_assistant.json
+++ b/sources/led-drivers/schemas/schema-home_assistant.json
@@ -8,11 +8,27 @@
 			"required" : true,
 			"propertyOrder" : 1
 		},
+                "homeAssistantPort": {
+                        "type": "integer",
+                        "title": "edt_dev_spec_networkDevicePort_title",
+                        "default": 8123,
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "required": true,
+                        "propertyOrder": 2
+                },
+                "useSSL": {
+                        "type": "boolean",
+                        "format": "checkbox",
+                        "title": "edt_conf_mqtt_is_ssl_title",
+                        "default" : false,
+                        "propertyOrder" : 3
+                },
 		"longLivedAccessToken" : {
 			"type": "string",
-			"title":"edt_dev_auth_key_title",
+			"title": "edt_dev_auth_key_title",
 			"required" : true,
-			"propertyOrder" : 2
+			"propertyOrder" : 4
 		},
 		"transition": {
 			"type": "integer",
@@ -22,7 +38,7 @@
 			"minimum": 0,
 			"maximum": 3000,
 			"required": true,
-			"propertyOrder": 3
+			"propertyOrder": 5
 		},
 		"constantBrightness": {
 			"type": "integer",
@@ -31,14 +47,14 @@
 			"minimum": 0,
 			"maximum": 255,
 			"required": true,
-			"propertyOrder": 4
+			"propertyOrder": 6
 		},
 		"restoreOriginalState": {
 			"type": "boolean",
 			"format": "checkbox",
-			"title":"edt_dev_spec_restoreOriginalState_title",
+			"title": "edt_dev_spec_restoreOriginalState_title",
 			"default" : false,
-			"propertyOrder" : 5
+			"propertyOrder" : 7
 		},
 		"maxRetry": {
 			"type" : "integer",
@@ -49,12 +65,12 @@
 			"maximum" : 300,
 			"default" : 60,
 			"required" : true,
-			"propertyOrder" : 6
+			"propertyOrder" : 8
 		},
 		"lamps": {
 			"type": "array",
 			"title":"edt_dev_spec_lights_title",
-			"propertyOrder" : 7,
+			"propertyOrder" : 9,
 			"uniqueItems" : true,
 			"items" : {
 				"type" : "object",


### PR DESCRIPTION
Updated Home Assistant module to enable SSL.

Adds option to ProviderRestApi constructor to enable SSL if specified in the init method.

Have not stuffed around with the Wizard page yet.