### PR TITLE
Fix for OpenSSL on macOS (needed by https/tls)

### DIFF
--- a/cmake/installers.cmake
+++ b/cmake/installers.cmake
@@ -65,19 +65,6 @@ macro(DeployApple TARGET)
 					endif()
 				endif()
 
-				execute_process(
-					COMMAND brew --prefix openssl@1.1
-					RESULT_VARIABLE BREW_OPENSSL1
-					OUTPUT_VARIABLE BREW_OPENSSL1_PATH
-					OUTPUT_STRIP_TRAILING_WHITESPACE
-				)
-				if (BREW_OPENSSL1 EQUAL 0 AND EXISTS "${BREW_OPENSSL1_PATH}/lib")
-					set(BREW_OPENSSL1_LIB "${BREW_OPENSSL1_PATH}/lib")
-					message("Found OpenSSL@1.1 at ${BREW_OPENSSL1_LIB}")
-					file(GLOB filesSSL1 "${BREW_OPENSSL1_LIB}/*")
-					list (APPEND filesSSL ${filesSSL1})
-				endif()
-
 				#OpenSSL
 				if(filesSSL)
 					list( REMOVE_DUPLICATES filesSSL)
@@ -159,8 +146,9 @@ macro(DeployApple TARGET)
 					endif()
 				endforeach()
 
-			include(BundleUtilities)							
+			include(BundleUtilities)										
 			fixup_bundle("${CMAKE_INSTALL_PREFIX}/hyperhdr.app" "${MYQT_PLUGINS}" "${CMAKE_INSTALL_PREFIX}/hyperhdr.app/Contents/lib")
+			fixup_bundle("${CMAKE_INSTALL_PREFIX}/hyperhdr.app" "" "")
 				
 			file(REMOVE_RECURSE "${CMAKE_INSTALL_PREFIX}/hyperhdr.app/Contents/lib")			
 			file(REMOVE_RECURSE "${CMAKE_INSTALL_PREFIX}/share")

--- a/sources/api/HyperAPI.cpp
+++ b/sources/api/HyperAPI.cpp
@@ -1296,8 +1296,8 @@ void HyperAPI::handleTunnel(const QJsonObject& message, const QString& command, 
 
 		if (service == "hue" || service == "home_assistant")
 		{
-			QUrl tempUrl("http://"+ip);
-			if ((path.indexOf("/clip/v2") != 0 && path.indexOf("/api") != 0) || ip.indexOf("/") >= 0)
+			QUrl tempUrl(ip.startsWith("http") ? ip : "http://" + ip);
+			if (!path.startsWith("/clip/v2") && !path.startsWith("/api"))
 			{
 				sendErrorReply("Invalid path", full_command, tan);
 				return;
@@ -1305,7 +1305,7 @@ void HyperAPI::handleTunnel(const QJsonObject& message, const QString& command, 
 
 			ProviderRestApi provider;
 
-			QUrl url = QUrl((path.startsWith("/clip/v2") ? "https://" : "http://")+tempUrl.host() + ((service == "home_assistant" && tempUrl.port() >= 0) ? ":" + QString::number(tempUrl.port()) : "") + path);
+			QUrl url = QUrl(QString("%1://").arg(tempUrl.scheme()) + tempUrl.host() + ((service == "home_assistant" && tempUrl.port() >= 0) ? ":" + QString::number(tempUrl.port()) : "") + path);
 
 			Debug(_log, "Tunnel request for: %s", QSTRING_CSTR(url.toString()));
 

--- a/sources/led-drivers/net/DriverNetPhilipsHue.cpp
+++ b/sources/led-drivers/net/DriverNetPhilipsHue.cpp
@@ -133,15 +133,13 @@ bool LedDevicePhilipsHueBridge::init(QJsonObject deviceConfig)
 		}
 		else
 		{
-			QStringList addressparts = address.split(':', Qt::SkipEmptyParts);
-			_hostname = addressparts[0];
+			QUrl url(address);
+
+			_hostname = url.host();
 			log("Hostname/IP", "%s", QSTRING_CSTR(_hostname));
 
-			if (addressparts.size() > 1)
-			{
-				_apiPort = addressparts[1].toInt();
-				log("Port", "%u", _apiPort);
-			}
+			_apiPort = url.port(url.scheme().toLower() == "https" ? 443 : 80);
+			log("Port", "%u", _apiPort);
 
 			_username = deviceConfig["username"].toString();
 

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -894,7 +894,6 @@ function checkHueBridge(cb, hueUser)
 					useV2Api=parseInt(json.swversion)>1948086000&&useV2ApiConfig
 					conf_editor.getEditor("root.specificOptions.output").setValue(hueIPs[hueIPsinc].internalipaddress);
 					$('#wiz_hue_discovered').html("Bridge: " + json.name + ", Modelid: " + json.modelid + ", API-Version: " + json.apiversion);
-					console.log(`CheckHueBridge => useV2Api: ${useV2Api}, swversion: ${json.swversion}, useV2ApiConfig: ${useV2ApiConfig}`);
 					cb(true);
 				}
 				else
@@ -1246,7 +1245,10 @@ function createHueUser()
 					{
 						if (typeof r[0].error != 'undefined')
 						{
-							console.log(connectionRetries + ": link not pressed");
+							if (r[0].error.type = 101)
+								console.log(`Link button not pressed: ${JSON.stringify(r[0].error)} (${connectionRetries})`);
+							else
+								console.log(`An error occurred: ${JSON.stringify(r[0].error)} (${connectionRetries})`);
 						}
 						if (typeof r[0].success != 'undefined')
 						{
@@ -1265,7 +1267,6 @@ function createHueUser()
 									$('#clientkey').val(r[0].success.clientkey);
 									conf_editor.getEditor("root.specificOptions.clientkey").setValue(r[0].success.clientkey);
 								}
-								console.log(`CreateHueUser for EntertainmentAPI: ${JSON.stringify(r, null, 2)}`);
 							}
 							checkHueBridge(checkUserResult, r[0].success.username);
 							clearInterval(UserInterval);

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -960,6 +960,7 @@ function identHueId(id, off, oState)
 
 function switchToHttps(ip)
 {
+	ip = ip.replace(/^https:\/\//, "");
 	ip = ip.replace(/^http:\/\//, "");
 	ip = ip.replace(/:80$/, "");
 	ip = "https://" + ip;

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -958,6 +958,14 @@ function identHueId(id, off, oState)
 	tunnel_hue_put($('#ip').val(), '/api/' + $('#user').val() + '/lights/' + id + '/state', put_data);
 }
 
+function switchToHttps(ip)
+{
+	ip = ip.replace(/^http:\/\//, "");
+	ip = ip.replace(/:80$/, "");
+	ip = "https://" + ip;
+	return ip;
+}
+
 async function discover_hue_bridges()
 {
 	const res = await requestLedDeviceDiscovery('philipshue');
@@ -980,6 +988,11 @@ async function discover_hue_bridges()
 				console.log("Device:", device);
 
 				var ip = device.ip + ":" + device.port;
+				if (hueType == 'philipshueentertainment')
+				{
+					ip = switchToHttps(ip);
+				}
+
 				console.log("Host:", ip);
 
 				hueIPs.push({ internalipaddress: ip });
@@ -1162,6 +1175,10 @@ function beginWizardHue()
 	else
 	{
 		var ip = eV("output");
+		if (hueType == 'philipshueentertainment')
+		{
+			ip = switchToHttps(ip);
+		}
 		$('#ip').val(ip);
 		hueIPs.unshift({ internalipaddress: ip });
 		if (usr != "")
@@ -1177,7 +1194,12 @@ function beginWizardHue()
 	{
 		if ($('#ip').val() != "")
 		{
-			hueIPs.unshift({ internalipaddress: $('#ip').val() })
+			var ip = $('#ip').val();
+			if (hueType == 'philipshueentertainment')
+			{
+				ip = switchToHttps(ip);
+			}
+			hueIPs.unshift({ internalipaddress: ip });
 			hueIPsinc = 0;
 		}
 		else discover_hue_bridges();

--- a/www/js/wizard.js
+++ b/www/js/wizard.js
@@ -894,6 +894,7 @@ function checkHueBridge(cb, hueUser)
 					useV2Api=parseInt(json.swversion)>1948086000&&useV2ApiConfig
 					conf_editor.getEditor("root.specificOptions.output").setValue(hueIPs[hueIPsinc].internalipaddress);
 					$('#wiz_hue_discovered').html("Bridge: " + json.name + ", Modelid: " + json.modelid + ", API-Version: " + json.apiversion);
+					console.log(`CheckHueBridge => useV2Api: ${useV2Api}, swversion: ${json.swversion}, useV2ApiConfig: ${useV2ApiConfig}`);
 					cb(true);
 				}
 				else
@@ -1264,6 +1265,7 @@ function createHueUser()
 									$('#clientkey').val(r[0].success.clientkey);
 									conf_editor.getEditor("root.specificOptions.clientkey").setValue(r[0].success.clientkey);
 								}
+								console.log(`CreateHueUser for EntertainmentAPI: ${JSON.stringify(r, null, 2)}`);
 							}
 							checkHueBridge(checkUserResult, r[0].success.username);
 							clearInterval(UserInterval);


### PR DESCRIPTION
There was a conflict between OpenSSL1.1 and OpenSSL 3 and an incorrect R_PATH variable in the libraries included with the macOS installer, which leads in HyperHDR to incorrect operation of the https protocol, including HyperHDR https instance and some network LED drivers ex. for Philips Hue devices.
Also fixed accreditation creation for Philips Hue Bridge Pro
This PR fixes the issues #1289 #1285