### PR TITLE
change DX11 Grabber automatic display select behaviour

### DIFF
--- a/include/base/Grabber.h
+++ b/include/base/Grabber.h
@@ -215,6 +215,7 @@ protected:
 		QStringList					framerates = QStringList();
 		DeviceControlCapability		brightness, contrast, saturation, hue;
 		QList<DevicePropertiesItem> valid = QList<DevicePropertiesItem>();
+		bool						isPrimary = false;
 	};
 
 	QMap<QString, DeviceProperties> _deviceProperties;

--- a/sources/grabber/windows/DX/DxGrabber.cpp
+++ b/sources/grabber/windows/DX/DxGrabber.cpp
@@ -166,7 +166,7 @@ bool DxGrabber::init()
 	{
 		QString foundDevice = "";
 		bool    autoDiscovery = (QString::compare(_deviceName, Grabber::AUTO_SETTING, Qt::CaseInsensitive) == 0);
-
+		
 		enumerateDevices(true);
 
 
@@ -181,7 +181,15 @@ bool DxGrabber::init()
 		if (autoDiscovery)
 		{
 			Debug(_log, "Forcing auto discovery device");
-			if (!_deviceProperties.isEmpty())
+			for (auto [key, properties] : _deviceProperties.asKeyValueRange())
+			{
+				if (properties.isPrimary)
+				{
+					foundDevice = key;
+				}
+			}
+
+			if (foundDevice.isNull()) //fallback in case none is primary.. unsure if that can happen
 			{
 				foundDevice = _deviceProperties.firstKey();
 				Debug(_log, "Auto discovery set to %s", QSTRING_CSTR(foundDevice));
@@ -234,7 +242,7 @@ void DxGrabber::enumerateDevices(bool /*silent*/)
 	{
 		DeviceProperties properties;
 		DXGI_ADAPTER_DESC1 pDesc;
-
+		MONITORINFOEX mi{}; mi.cbSize = sizeof(mi);
 		pAdapter->GetDesc1(&pDesc);
 
 		IDXGIOutput* pOutput;
@@ -243,15 +251,15 @@ void DxGrabber::enumerateDevices(bool /*silent*/)
 		{
 			DXGI_OUTPUT_DESC oDesc;
 			pOutput->GetDesc(&oDesc);
-
+			properties.isPrimary = (GetMonitorInfo(oDesc.Monitor, &mi) && (mi.dwFlags & MONITORINFOF_PRIMARY));
 			QString dev = QString::fromWCharArray(oDesc.DeviceName) + "|" + QString::fromWCharArray(pDesc.Description);
 			_deviceProperties.insert(dev, properties);
-
 			SafeRelease(&pOutput);
 		}
 
 		if (j > 1)
 		{
+			properties = DeviceProperties();
 			_deviceProperties.insert(MULTI_MONITOR + "|" + QString::fromWCharArray(pDesc.Description), properties);
 		}
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**


**Other information:**
When using HyperHDR with multiple Monitors, the display numbering is inconsistent. One has to manually change the display to use frequently, as Windows does not guarantee consistent win32 numberings. the Automatic select feature also just selects the display thats first enumerated, which has the same problem.
I changed the behaviour of the auto select function to select the Primary Monitor all the time, as I think/hope this is the most commom usecase.
I created this PR after Posting this: https://github.com/awawa-dev/HyperHDR/discussions/1321
and realizing that its very easy to just fix. I hope the PR satisfies all requirements, If not let me know :)
