### PR TITLE
Smoothing: restore continuous output control + stricter end detection

### DIFF
--- a/include/infinite-color-engine/InfiniteExponentialInterpolator.h
+++ b/include/infinite-color-engine/InfiniteExponentialInterpolator.h
@@ -32,6 +32,5 @@ private:
 	float _tau  = 150.0f;
 	float _startAnimationTimeMs = 0.0f;
 	float _targetTime = 0.0f;
-	float _lastUpdate = 0.0f;
-	bool _isAnimationComplete = true;
+	float _lastUpdate = 0.0f;	
 };

--- a/include/infinite-color-engine/InfiniteHybridInterpolator.h
+++ b/include/infinite-color-engine/InfiniteHybridInterpolator.h
@@ -40,5 +40,4 @@ private:
 	float _stiffness = 150.0f;
 	float _damping = 26.0f;
 	float _maxLuminanceChangePerStep = 0.02f;
-	bool _isAnimationComplete = true;
 };

--- a/include/infinite-color-engine/InfiniteInterpolator.h
+++ b/include/infinite-color-engine/InfiniteInterpolator.h
@@ -12,6 +12,9 @@
 #include <linalg.h>
 
 class InfiniteInterpolator {
+protected:
+	bool _isAnimationComplete = true;
+
 public:
 	virtual ~InfiniteInterpolator() = default;
 
@@ -23,5 +26,5 @@ public:
 	virtual void setSpringiness(float /*stiffness*/, float /*damping*/) {};
 	virtual void setMaxLuminanceChangePerFrame(float /*maxYChangePerFrame*/) {};
 	virtual void setSmoothingFactor(float /*factor*/) {};
-
+	bool isAnimationComplete() { return _isAnimationComplete; }
 };

--- a/include/infinite-color-engine/InfiniteRgbInterpolator.h
+++ b/include/infinite-color-engine/InfiniteRgbInterpolator.h
@@ -34,5 +34,4 @@ private:
 	float _startAnimationTimeMs = 0.0f;
 	float _targetTime = 0.0f;
 	float _lastUpdate = 0.0f;
-	bool _isAnimationComplete = true;
 };

--- a/include/infinite-color-engine/InfiniteSmoothing.h
+++ b/include/infinite-color-engine/InfiniteSmoothing.h
@@ -65,7 +65,6 @@ private:
 	QMutex _dataSynchro;
 
 	bool _continuousOutput;
-	bool _flushFrame;
 
 	enum class SmoothingType { Stepper = 0, RgbInterpolator = 1, YuvInterpolator = 2, HybridInterpolator = 3, ExponentialInterpolator = 4};
 	static QString EnumSmoothingTypeToString(SmoothingType type);

--- a/include/infinite-color-engine/InfiniteStepperInterpolator.h
+++ b/include/infinite-color-engine/InfiniteStepperInterpolator.h
@@ -32,5 +32,4 @@ private:
 	float _startAnimationTimeMs = 0.0f;
 	float _targetTime = 0.0f;
 	float _lastUpdate = 0.0f;
-	bool _isAnimationComplete = true;
 };

--- a/include/infinite-color-engine/InfiniteYuvInterpolator.h
+++ b/include/infinite-color-engine/InfiniteYuvInterpolator.h
@@ -38,5 +38,4 @@ private:
 	float _lastUpdate = 0.0f;
 	float _maxLuminanceChangePerStep = 0.02f;
 	float _smoothingFactor = 0.0f;
-	bool _isAnimationComplete = true;
 };

--- a/sources/infinite-color-engine/InfiniteExponentialInterpolator.cpp
+++ b/sources/infinite-color-engine/InfiniteExponentialInterpolator.cpp
@@ -113,7 +113,7 @@ void InfiniteExponentialInterpolator::updateCurrentColors(float currentTimeMs)
 	// limits[2] = 60/255  => stary limitMax
 
 	auto computeChannelVec = [&](float3& cur, const float3& diff) -> bool {
-		const float FINISH_COMPONENT_THRESHOLD = 2.0f / 255.0f;
+		const float FINISH_COMPONENT_THRESHOLD = 0.2f / 255.0f;
 
 		float val = linalg::maxelem(linalg::abs(diff));
 

--- a/sources/infinite-color-engine/InfiniteHybridInterpolator.cpp
+++ b/sources/infinite-color-engine/InfiniteHybridInterpolator.cpp
@@ -122,7 +122,7 @@ void InfiniteHybridInterpolator::updateCurrentColors(float currentTimeMs) {
 	_lastUpdate = currentTimeMs;
 
 	auto computeChannelVec = [&](float3& cur, const float3& diff, float3& vel) -> bool {
-		const float FINISH_COMPONENT_THRESHOLD = 0.0013732906f;
+		const float FINISH_COMPONENT_THRESHOLD = 0.0013732906f / 10.f;
 		const float VELOCITY_THRESHOLD = 0.0005f;
 
 		if (linalg::maxelem(linalg::abs(diff)) < FINISH_COMPONENT_THRESHOLD && // color match

--- a/sources/infinite-color-engine/InfiniteRgbInterpolator.cpp
+++ b/sources/infinite-color-engine/InfiniteRgbInterpolator.cpp
@@ -140,7 +140,7 @@ void InfiniteRgbInterpolator::updateCurrentColors(float currentTimeMs)
 	// limits[2] = 60/255  => stary limitMax
 
 	auto computeChannelVec = [&](float3& cur, const float3& diff) -> bool {
-		const float FINISH_COMPONENT_THRESHOLD = 1.5f / 255.0f;
+		const float FINISH_COMPONENT_THRESHOLD = 0.2f / 255.0f;
 
 		float val = linalg::maxelem(linalg::abs(diff));
 

--- a/sources/infinite-color-engine/InfiniteStepperInterpolator.cpp
+++ b/sources/infinite-color-engine/InfiniteStepperInterpolator.cpp
@@ -118,7 +118,7 @@ void InfiniteStepperInterpolator::updateCurrentColors(float currentTimeMs)
 	// limits[2] = 60/255  => stary limitMax
 
 	auto computeChannelVec = [&](float3& cur, const float3& diff) -> bool {
-		const float FINISH_COMPONENT_THRESHOLD = 1.5f / 255.0f;
+		const float FINISH_COMPONENT_THRESHOLD = 0.2f / 255.0f;
 
 		float val = linalg::maxelem(linalg::abs(diff));
 

--- a/sources/infinite-color-engine/InfiniteYuvInterpolator.cpp
+++ b/sources/infinite-color-engine/InfiniteYuvInterpolator.cpp
@@ -141,7 +141,7 @@ void InfiniteYuvInterpolator::updateCurrentColors(float currentTimeMs)
 	_lastUpdate = currentTimeMs;
 
 	auto computeChannelVec = [&](float3& cur, const float3& diff) -> bool {
-		const float FINISH_COMPONENT_THRESHOLD = 0.0013732906f;
+		const float FINISH_COMPONENT_THRESHOLD = 0.0013732906f / 10.f;
 
 		float val = linalg::maxelem(linalg::abs(diff));
 


### PR DESCRIPTION
- Restore continuous output control: while migrating to the Infinite Color Engine, it was always enabled despite user settings.  
  This caused unnecessary writes to the light driver even when colors hadn't changed.

- Stricter end-of-interpolation detection: it now jumps to the end when RGB is within ~0.2/255.0 of the target value.  
  YUV difference is also checked and should be within a similar range. Both in taxicab geometry.
  
- Restore cooldown feature to repeat last color few times (3) before switching off if continuous output is disabled