### PR TITLE
Fix remote tab JSON parsing error caused by missing black color definition in JSON API scheme

### DIFF
--- a/sources/api/JSONRPC_schema/schema-adjustment.json
+++ b/sources/api/JSONRPC_schema/schema-adjustment.json
@@ -95,6 +95,17 @@
 					"minItems": 3,
 					"maxItems": 3
 				},
+				"black": {
+					"type": "array",
+					"required": false,
+					"items" : {
+						"type": "integer",
+						"minimum": 0,
+						"maximum": 255
+					},
+					"minItems": 3,
+					"maxItems": 3
+				},
 				"scaleOutput" :
 				{
 					"type" : "number",


### PR DESCRIPTION
This PR fixes a JSON schema validation warning occurring in the Remote Tab when switching the calibration type to RGBCMYK instead of default RGB mode in the Live calibration panel.

The issue was caused by a missing black color field definition in the local API JSON schema. When the user selects the RGBCMYK mode (by disabling RGB Calibration), the API sends a black value that was previously unrecognized, leading to a schema invalid warning ("Errors during specific message validation, please consult the HyperHDR Log") and preventing correct data synchronization. The RGBCMYK color adjustment command via JSON API was also affected when a black color target was specified.