### PR TITLE
Migrate to standard OS config location if ~/.hyperhdr folder is missing

### DIFF
--- a/cmake/linux/resources/hyperhdr.desktop
+++ b/cmake/linux/resources/hyperhdr.desktop
@@ -1,11 +1,11 @@
 [Desktop Entry]
 Name=HyperHDR
 GenericName=HyperHDR Ambient Lighting
-Comment=HyperHDR mimics the well known Ambilight from Philips
+Comment=Real-time ambient lighting system for TVs, monitors and LEDs
 Icon=/usr/share/pixmaps/hyperhdr/hyperhdr_128.png
 Terminal=false
 TryExec=hyperhdr
 Exec=hyperhdr
 Type=Application
 StartupNotify=false
-Categories=Application;
+Categories=AudioVideo;Video;Settings;Multimedia;

--- a/sources/hyperhdr/main.cpp
+++ b/sources/hyperhdr/main.cpp
@@ -14,6 +14,7 @@
 	#include <cstdio>
 #endif
 
+#include <QStandardPaths>
 #include <csignal>
 
 #if !defined(__APPLE__) && !defined(_WIN32)
@@ -107,7 +108,7 @@ QCoreApplication* createApplication(bool& isGuiApp, int& argc, char* argv[])
 #endif
 
 	QCoreApplication* app = new QCoreApplication(argc, argv);
-	QCoreApplication::setApplicationName("HyperHdr");
+	QCoreApplication::setApplicationName("HyperHDR");
 	QCoreApplication::setApplicationVersion(HYPERHDR_VERSION);
 	// add optional library path
 	QCoreApplication::addLibraryPath(QCoreApplication::applicationDirPath() + "/../lib");
@@ -140,8 +141,13 @@ int main(int argc, char** argv)
 	Parser parser("HyperHDR Daemon");
 	parser.addHelpOption();
 
+	QString defaultDataPath = QDir(QDir::homePath()).absoluteFilePath(".hyperhdr");
+	if (!QDir(defaultDataPath).exists()) {
+		defaultDataPath = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+	}
+
 	BooleanOption& versionOption = parser.add<BooleanOption>(0x0, "version", "Show version information");
-	Option& userDataOption = parser.add<Option>('u', "userdata", "Overwrite user data path, defaults to home directory of current user (%1)", QDir::homePath() + "/.hyperhdr");
+	Option& userDataOption = parser.add<Option>('u', "userdata", "Overwrite user data path, defaults to home directory of current user (%1)", defaultDataPath);
 	BooleanOption& resetPassword = parser.add<BooleanOption>(0x0, "resetPassword", "Lost your password? Reset it with this option back to 'hyperhdr'");
 	BooleanOption& deleteDB = parser.add<BooleanOption>(0x0, "deleteDatabase", "Start all over? This Option will delete the database");
 	BooleanOption& silentOption = parser.add<BooleanOption>('s', "silent", "Do not print any outputs");


### PR DESCRIPTION
If default `~/.hyperhdr` folder does not exists, create it and propose it as default in the default OS location and use it - otherwise use standard `~/.hyperhdr` directory as a base for HyperHDR user data storage.

Default OS locations:

| Platform | Example Path (HyperHDR) |
| :--- | :--- |
| **Linux** | `~/.config/HyperHDR` |
| **macOS** | `~/Library/Preferences/HyperHDR` |
| **Windows** | `C:\Users\<User>\AppData\Local\HyperHDR` |

Resolves #1425