### PR TITLE
fix: RFC-compliant HTTP reason phrases in QtHttpReply

### DIFF
--- a/sources/webserver/QtHttpReply.cpp
+++ b/sources/webserver/QtHttpReply.cpp
@@ -36,10 +36,10 @@ const QByteArray QtHttpReply::getStatusTextForCode(QtHttpReply::StatusCode statu
 {
 	switch (statusCode)
 	{
-	case Ok:         return QByteArrayLiteral("OK.");
-	case BadRequest: return QByteArrayLiteral("Bad request !");
-	case Forbidden:  return QByteArrayLiteral("Forbidden !");
-	case NotFound:   return QByteArrayLiteral("Not found !");
+	case Ok:         return QByteArrayLiteral("OK");
+	case BadRequest: return QByteArrayLiteral("Bad Request");
+	case Forbidden:  return QByteArrayLiteral("Forbidden");
+	case NotFound:   return QByteArrayLiteral("Not Found");
 	default:         return QByteArrayLiteral("");
 	}
 }


### PR DESCRIPTION
**Summary**

`QtHttpReply::getStatusTextForCode` returns reason phrases with non-standard punctuation:

| Code | Before | After |
|------|--------|-------|
| 200  | `OK.` | `OK` |
| 400  | `Bad request !` | `Bad Request` |
| 403  | `Forbidden !` | `Forbidden` |
| 404  | `Not found !` | `Not Found` |

RFC 7230 §3.1.2 defines the status line as `HTTP-version SP status-code SP reason-phrase CRLF`. Reason phrases with punctuation like trailing periods and exclamation marks cause strict HTTP parsers to treat the response as malformed. Concretely, Caddy's `reverse_proxy` directive returns a zero-length body to the client when it receives these non-standard status lines.

The fix normalises all four phrases to the IANA-registered strings.

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**Other information:**

Verified end-to-end: built from source in Docker, confirmed `nc` probe returns `HTTP/1.1 200 OK` (no trailing period), and Caddy `reverse_proxy` now forwards non-empty response bodies.