### PR TITLE
Fix: Allow capturing non-primary macOS displays

### DIFF
--- a/.github/workflows/cache_cleaner.yml
+++ b/.github/workflows/cache_cleaner.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - run: gh cache delete --all --ref "refs/heads/${{ github.head_ref }}"
+      - run: gh cache delete --all --ref "refs/heads/${{ github.head_ref }}" --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ github.token }}
   clean_PR_artifacts:

--- a/.github/workflows/cache_cleaner.yml
+++ b/.github/workflows/cache_cleaner.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - run: gh cache delete --all --ref "refs/heads/${{ github.head_ref }}" --repo ${{ github.repository }}
+      - run: gh cache delete --all --ref "refs/heads/${{ github.head_ref }}"
         env:
           GH_TOKEN: ${{ github.token }}
   clean_PR_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Migrate to standard OS config location if ~/.hyperhdr folder is missing (#1472) - v22beta2 🆕
 - Add Philips WiZ support (driver + web wizard) Thanks @user83749 (#1469) - v22beta2 🆕
 - Add aspect ratio detection for Amlogic grabber. Thanks @santievil (#1476) - v22beta2 🆕
+- Fix: Allow capturing non-primary macOS displays (#1530) - v22beta2 🆕
 - Fix remote tab JSON parsing error caused by missing black color in API JSON scheme (#1471) - v22beta2 🆕
 - Implement DDP / Hyperk drivers (#1467) - v22beta2 🆕
 - Fix: Initial smoothing surge after period of static video input (#1410) - v22beta2 🆕

--- a/sources/grabber/osx/macOS/macOsGrabber.mm
+++ b/sources/grabber/osx/macOS/macOsGrabber.mm
@@ -304,6 +304,7 @@ void macOsGrabber::grabFrame()
 				streamConfig.width = displayBounds.size.width * scaleAspect;
 				streamConfig.height = displayBounds.size.height * scaleAspect;
 				streamConfig.sourceRect = displayBounds;
+				streamConfig.sourceRect = CGRectMake(0, 0, displayBounds.size.width, displayBounds.size.height);
 				streamConfig.captureResolution = SCCaptureResolutionBest;
 				streamConfig.scalesToFit = false;
 				streamConfig.queueDepth = 1;
@@ -319,6 +320,11 @@ void macOsGrabber::grabFrame()
 							decodeFrame(capturedImage);
 
 							CGImageRelease(capturedImage);
+						}
+						else if (error)
+						{
+							QString errorMessage = QString::fromNSString([error localizedDescription]);
+							Error(_log, "captureImageWithFilter Error: {:s}", errorMessage);
 						}
 					}
 				];


### PR DESCRIPTION
Allow capturing displays other than the primary display