### PR TITLE
Add a gaussian blur to image and LEDs to have smooth gradient

### DIFF
--- a/include/base/ImageToLedManager.h
+++ b/include/base/ImageToLedManager.h
@@ -8,12 +8,21 @@
 #endif
 
 #include <image/Image.h>
+#include <image/GaussianBlur.h>
 #include <utils/Logger.h>
 #include <base/LedString.h>
 #include <base/ImageColorAveraging.h>
 #include <blackborder/BlackBorderProcessor.h>
 
 #include <linalg.h>
+#include <vector>
+
+struct LedBrightnessRange
+{
+    int from;
+    int to;
+    float brightness;
+};
 
 class HyperHdrInstance;
 
@@ -33,7 +42,10 @@ public:
 	static QString mappingTypeToStr(int mappingType);
 
 	void setSparseProcessing(bool sparseProcessing);
-	void processFrame(std::vector<linalg::aliases::float3>& ledColors, const Image<ColorRgb>& frameBuffer);
+	void setGaussianBlurRadius(int radius);
+	void setLedBrightnessRanges(const std::vector<LedBrightnessRange>& ranges);
+	void setBlackThreshold(int threshold);
+	void processFrame(std::vector<linalg::aliases::float3>& ledColors, const Image<ColorRgb>& frameBuffer, Image<ColorRgb>& outImage);
 
 signals:
 	void SignalImageToLedsMappingChanged(int mappingType);
@@ -65,4 +77,7 @@ private:
 	std::unique_ptr<hyperhdr::ImageColorAveraging> _colorAveraging;
 	int		_mappingType;
 	bool	_sparseProcessing;
+	int _gaussianBlurRadius = 0;
+	std::vector<LedBrightnessRange> _brightnessRanges;
+	float _blackThreshold = 0.0f;
 };

--- a/include/image/GaussianBlur.h
+++ b/include/image/GaussianBlur.h
@@ -1,0 +1,98 @@
+// NOUVEAU FICHIER : include/image/GaussianBlur.h
+// Flou gaussien séparable haute performance pour HyperHDR
+// Par 2 passes 1D (horizontal puis vertical) => O(n * kSize) au lieu de O(n * kSize²)
+
+#pragma once
+
+#include <image/Image.h>
+#include <image/ColorRgb.h>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+namespace GaussianBlur
+{
+    // Construit un noyau gaussien 1D normalisé de rayon `radius`
+    inline std::vector<float> buildKernel(int radius)
+    {
+        if (radius <= 0) return {};
+        const int size = 2 * radius + 1;
+        std::vector<float> kernel(size);
+        const float sigma = radius / 2.5f;
+        float sum = 0.0f;
+        for (int i = -radius; i <= radius; ++i)
+        {
+            float val = std::exp(-(static_cast<float>(i * i)) / (2.0f * sigma * sigma));
+            kernel[i + radius] = val;
+            sum += val;
+        }
+        for (auto& v : kernel) v /= sum;
+        return kernel;
+    }
+
+    // Applique un flou gaussien séparable sur l'image (in-place)
+    // radius = 0 : désactivé / aucune modification
+    // radius = 1 : léger (kernel 3x3)
+    // radius = 5 : fort (kernel 11x11)
+    inline void apply(Image<ColorRgb>& image, int radius)
+    {
+        if (radius <= 0) return;
+
+        const int width  = static_cast<int>(image.width());
+        const int height = static_cast<int>(image.height());
+
+        if (width < 2 || height < 2) return;
+
+        const auto kernel = buildKernel(radius);
+
+        // Buffer temporaire pour stocker le résultat de la passe horizontale
+        Image<ColorRgb> tmp(width, height);
+
+        // --- Passe horizontale ---
+        for (int y = 0; y < height; ++y)
+        {
+            for (int x = 0; x < width; ++x)
+            {
+                float r = 0.0f, g = 0.0f, b = 0.0f;
+                for (int k = -radius; k <= radius; ++k)
+                {
+                    const int sx = std::clamp(x + k, 0, width - 1);
+                    const ColorRgb& px = image(sx, y);
+                    const float w = kernel[k + radius];
+                    r += px.red   * w;
+                    g += px.green * w;
+                    b += px.blue  * w;
+                }
+                tmp(x, y) = ColorRgb{
+                    static_cast<uint8_t>(std::clamp(r, 0.0f, 255.0f)),
+                    static_cast<uint8_t>(std::clamp(g, 0.0f, 255.0f)),
+                    static_cast<uint8_t>(std::clamp(b, 0.0f, 255.0f))
+                };
+            }
+        }
+
+        // --- Passe verticale (sur tmp -> image) ---
+        for (int y = 0; y < height; ++y)
+        {
+            for (int x = 0; x < width; ++x)
+            {
+                float r = 0.0f, g = 0.0f, b = 0.0f;
+                for (int k = -radius; k <= radius; ++k)
+                {
+                    const int sy = std::clamp(y + k, 0, height - 1);
+                    const ColorRgb& px = tmp(x, sy);
+                    const float w = kernel[k + radius];
+                    r += px.red   * w;
+                    g += px.green * w;
+                    b += px.blue  * w;
+                }
+                image(x, y) = ColorRgb{
+                    static_cast<uint8_t>(std::clamp(r, 0.0f, 255.0f)),
+                    static_cast<uint8_t>(std::clamp(g, 0.0f, 255.0f)),
+                    static_cast<uint8_t>(std::clamp(b, 0.0f, 255.0f))
+                };
+            }
+        }
+    }
+
+} // namespace GaussianBlur

--- a/sources/base/ImageToLedManager.cpp
+++ b/sources/base/ImageToLedManager.cpp
@@ -29,6 +29,7 @@
 #include <base/ImageToLedManager.h>
 #include <base/ImageColorAveraging.h>
 #include <blackborder/BlackBorderProcessor.h>
+#include <image/GaussianBlur.h>
 
 using namespace hyperhdr;
 using namespace linalg::aliases;
@@ -94,15 +95,34 @@ ImageToLedManager::ImageToLedManager(const LedString& ledString, HyperHdrInstanc
 
 void ImageToLedManager::handleSettingsUpdate(settings::type type, const QJsonDocument& config)
 {
-	if (type == settings::type::COLOR)
-	{
-		const QJsonObject& obj = config.object();
-		int newType = mappingTypeToInt(obj["imageToLedMappingType"].toString());
-		setLedMappingType(newType);
+    if (type == settings::type::COLOR)
+    {
+        const QJsonObject& obj = config.object();
+        int newType = mappingTypeToInt(obj["imageToLedMappingType"].toString());
+        setLedMappingType(newType);
 
-		bool newSparse = obj["sparse_processing"].toBool(false);
-		setSparseProcessing(newSparse);
-	}
+        bool newSparse = obj["sparse_processing"].toBool(false);
+        setSparseProcessing(newSparse);
+
+		std::vector<LedBrightnessRange> ranges;
+		const QJsonArray rangesArray = obj["ledBrightnessRanges"].toArray();
+		for (const QJsonValue& v : rangesArray)
+		{
+			const QJsonObject o = v.toObject();
+			LedBrightnessRange r;
+			r.from       = o["from"].toInt(0);
+			r.to         = o["to"].toInt(0);
+			r.brightness = static_cast<float>(o["brightness"].toDouble(1.0));
+			ranges.push_back(r);
+		}
+		setLedBrightnessRanges(ranges);
+
+        // AJOUTER CES LIGNES :
+        int newBlurRadius = obj["gaussianBlurRadius"].toInt(0);
+        setGaussianBlurRadius(newBlurRadius);
+	int newBlackThreshold = obj["blackThreshold"].toInt(0);
+	setBlackThreshold(newBlackThreshold);
+    }
 }
 
 void ImageToLedManager::setSize(unsigned width, unsigned height)
@@ -142,15 +162,43 @@ bool ImageToLedManager::blackBorderDetectorEnabled() const
 	return _borderProcessor->enabled();
 }
 
-void ImageToLedManager::processFrame(std::vector<float3>& ledColors, const Image<ColorRgb>& frameBuffer)
+void ImageToLedManager::processFrame(std::vector<float3>& ledColors, const Image<ColorRgb>& frameBuffer, Image<ColorRgb>& outImage)
 {
-	setSize(frameBuffer);;
-	verifyBorder(frameBuffer);
+    if (_gaussianBlurRadius > 0)
+    {
+        outImage = Image<ColorRgb>(frameBuffer.width(), frameBuffer.height());
+        memcpy(outImage.rawMem(), frameBuffer.rawMem(), frameBuffer.size());
+        GaussianBlur::apply(outImage, _gaussianBlurRadius);
+        setSize(outImage);
+        verifyBorder(outImage);
+        if (_colorAveraging != nullptr && _colorAveraging->width() == outImage.width() && _colorAveraging->height() == outImage.height())
+            _colorAveraging->process(ledColors, outImage);
+    }
+    else
+    {
+    // radius == 0 : outImage reste vide (width==0), l'appelant utilisera l'image originale
+    setSize(frameBuffer);
+    verifyBorder(frameBuffer);
+    if (_colorAveraging != nullptr && _colorAveraging->width() == frameBuffer.width() && _colorAveraging->height() == frameBuffer.height())
+        _colorAveraging->process(ledColors, frameBuffer);
+    }
+    // Appliquer la luminosité par plage
+    for (const auto& range : _brightnessRanges)
+    {
+        int end = std::min(range.to, static_cast<int>(ledColors.size()) - 1);
+        for (int i = range.from; i <= end; ++i)
+            ledColors[i] = linalg::clamp(ledColors[i] * range.brightness, 0.0f, 1.0f);
+    }
 
-	if (_colorAveraging != nullptr && _colorAveraging->width() == frameBuffer.width() && _colorAveraging->height() == frameBuffer.height())
-	{
-		_colorAveraging->process(ledColors, frameBuffer);
-	}
+    // Forcer le noir absolu sous le seuil
+    if (_blackThreshold > 0.0f)
+    {
+        for (auto& color : ledColors)
+        {
+            if (color.x < _blackThreshold && color.y < _blackThreshold && color.z < _blackThreshold)
+                color = float3{ 0.0f, 0.0f, 0.0f };
+        }
+    }
 }
 
 void ImageToLedManager::setSparseProcessing(bool sparseProcessing)
@@ -240,4 +288,22 @@ void ImageToLedManager::setSize(const Image<ColorRgb>& image)
 int ImageToLedManager::getLedMappingType() const
 {
 	return _mappingType;
+}
+
+void ImageToLedManager::setGaussianBlurRadius(int radius)
+{
+    _gaussianBlurRadius = std::max(0, std::min(radius, 30));
+    Debug(_log, "Gaussian blur radius set to: {:d}", _gaussianBlurRadius);
+}
+
+void ImageToLedManager::setLedBrightnessRanges(const std::vector<LedBrightnessRange>& ranges)
+{
+    _brightnessRanges = ranges;
+    Debug(_log, "LED brightness ranges updated: {:d} range(s)", static_cast<int>(ranges.size()));
+}
+
+void ImageToLedManager::setBlackThreshold(int threshold)
+{
+    _blackThreshold = std::clamp(threshold, 0, 30) / 255.0f;
+    Debug(_log, "Black threshold set to: {:d}/255", threshold);
 }

--- a/sources/base/schema/schema-color.json
+++ b/sources/base/schema/schema-color.json
@@ -25,6 +25,71 @@
 			"required" : true,
 			"propertyOrder" : 2
 		},
+		"gaussianBlurRadius" :
+		{
+			"type" : "integer",
+			"format": "stepper",
+			"step" : 1,
+			"title" : "Gaussian Blur Radius",
+			"required" : true,
+			"minimum" : 0,
+			"maximum": 30,
+			"default" : 0,
+			"propertyOrder" : 3
+		},
+		"blackThreshold" :
+		{
+			"type" : "integer",
+			"format": "stepper",
+			"step" : 1,
+			"title" : "Black Threshold (force LEDs off)",
+			"required" : true,
+			"minimum" : 0,
+			"maximum": 30,
+			"default" : 0,
+			"propertyOrder" : 4
+},
+		"ledBrightnessRanges" :
+		{
+			"type" : "array",
+			"title" : "LED Brightness Ranges",
+			"required" : false,
+			"propertyOrder" : 4,
+			"default" : [],
+			"items" :
+			{
+				"type" : "object",
+				"title" : "Range",
+				"properties" :
+				{
+					"from" :
+					{
+						"type" : "integer",
+						"title" : "From LED",
+						"minimum" : 0,
+						"default" : 0
+					},
+					"to" :
+					{
+						"type" : "integer",
+						"title" : "To LED",
+						"minimum" : 0,
+						"default" : 99
+					},
+					"brightness" :
+					{
+						"type" : "number",
+						"format" : "stepper",
+						"step" : 0.05,
+						"title" : "Brightness (0.0 - 1.0)",
+						"minimum" : 0.0,
+						"maximum" : 1.0,
+						"default" : 1.0
+					}
+				},
+				"additionalProperties" : false
+			}
+		},
 		"channelAdjustment" :
 		{
 			"type" : "array",
@@ -32,7 +97,7 @@
 			"minItems": 1,
 			"maxItems": 1,
 			"required" : true,
-			"propertyOrder" : 3,
+			"propertyOrder" : 5,
 			"items" :
 			{
 				"type" : "object",
@@ -286,7 +351,7 @@
 						"required" : true,
 						"minimum" : 0.1,
 						"maximum": 100.0,
-						"default" : 1.5,						
+						"default" : 1.5,
 						"propertyOrder" : 19
 					},
 					"luminanceGain" :
@@ -310,7 +375,7 @@
 						"required" : true,
 						"minimum" : 0,
 						"maximum": 10,
-						"default" : 1,						
+						"default" : 1,
 						"propertyOrder" : 23
 					},
 					"backlightThreshold" :


### PR DESCRIPTION
This add a gaussian blur effect to have smooth gradient on LEDs.
Recommanded setting: Max. stream width to 196, gaussian blur to 30.

There is also the return of brigthness per segment from LED indexe that is not on the 22 beta. And a black threshold to set from when the LEDs turn black.

Without:
<img width="1336" height="1194" alt="image" src="https://github.com/user-attachments/assets/0c336bae-abc4-458b-b82f-238fb71f8adf" />

With max:
<img width="1333" height="1222" alt="image" src="https://github.com/user-attachments/assets/97bd4969-ee70-4a0c-b705-ccd8821a08b5" />

LEDs Brigthness index:
<img width="1598" height="329" alt="image" src="https://github.com/user-attachments/assets/01e9d000-6416-433b-9841-d787a815dfd0" />

Black threshold:
<img width="1598" height="84" alt="image" src="https://github.com/user-attachments/assets/6b93951e-7e66-45f3-94ad-f2b641be0a4d" />


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
