### PR TITLE
Revert to Windows-2022

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -165,7 +165,10 @@ jobs:
 
   windows:
     name: Windows
-    runs-on: windows-2025
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2022]
     env:
       MSVC: 2022
       QT_VERSION: 6.8.3
@@ -181,7 +184,7 @@ jobs:
         id: cache-toolkit-windows
         with:
           path: ${{ env.TOOLKIT_DIR }}
-          key: ${{ runner.os }}-Toolkit-Qt.${{ env.QT_VERSION }}-NSIS-TurboJPEG
+          key: ${{ matrix.os }}-Toolkit-Qt.${{ env.QT_VERSION }}-NSIS-TurboJPEG
 
       - name: Python 3.13 for aqtinstall
         if: steps.cache-toolkit-windows.outputs.cache-hit != 'true'


### PR DESCRIPTION
Microsoft recently updated the Visual Studio environment on the latest GitHub Windows runners to VS2025 mid-cycle. This introduces significant risks of breaking changes and MSVC linking incompatibilities, particularly with our Qt dependencies fetched via `aqtinstall`, which are currently built and validated against the VS2022 toolchain.

While we appreciate Microsoft's enthusiasm for rapidly promoting VS2025, pushing a major toolchain upgrade onto existing runners without a proper transition period unnecessarily disrupts stable pipelines.

To ensure our CI remains reliable, predictable, and our Qt binaries continue to link correctly, we are locking the environment to the thoroughly tested VS2022 toolchain until a proper VS2025 migration can be validated.

Reference:
https://github.com/actions/runner-images/issues/14017