### PR TITLE
feat: add SP616E serial LED controller driver

### DIFF
--- a/include/led-drivers/serial/DriverSerialSP616E.h
+++ b/include/led-drivers/serial/DriverSerialSP616E.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "ProviderSerial.h"
+
+class DriverSerialSP616E : public ProviderSerial
+{
+public:
+	explicit DriverSerialSP616E(const QJsonObject& deviceConfig);
+	static LedDevice* construct(const QJsonObject& deviceConfig);
+
+private:
+	bool init(QJsonObject deviceConfig) override;
+	int writeFiniteColors(const std::vector<ColorRgb>& ledValues) override;
+
+	static bool isRegistered;
+};

--- a/sources/led-drivers/LedDeviceSchemas.qrc
+++ b/sources/led-drivers/LedDeviceSchemas.qrc
@@ -16,6 +16,7 @@
 		<file alias="schema-piblaster">schemas/schema-piblaster.json</file>
 		<file alias="schema-rawhid">schemas/schema-rawhid.json</file>
 		<file alias="schema-sedu">schemas/schema-sedu.json</file>
+		<file alias="schema-sp616e">schemas/schema-sp616e.json</file>
 		<file alias="schema-sk6812spi">schemas/schema-sk6812spi.json</file>
 		<file alias="schema-sk6822spi">schemas/schema-sk6822spi.json</file>
 		<file alias="schema-sk9822">schemas/schema-sk9822.json</file>

--- a/sources/led-drivers/schemas/schema-sp616e.json
+++ b/sources/led-drivers/schemas/schema-sp616e.json
@@ -1,0 +1,25 @@
+{
+	"type":"object",
+	"required":true,
+	"properties":{
+		"output": {
+			"type": "string",
+			"title":"edt_dev_spec_outputPath_title",
+			"default":"ttyACM0",
+			"propertyOrder" : 1
+		},
+		"rate": {
+			"type": "integer",
+			"title":"edt_dev_spec_baudrate_title",
+			"default": 115200,
+			"propertyOrder" : 2
+		},
+		"delayAfterConnect": {
+			"type": "integer",
+			"title":"edt_dev_spec_delayAfterConnect_title",
+			"default": 250,
+			"propertyOrder" : 3
+		}
+	},
+	"additionalProperties": true
+}

--- a/sources/led-drivers/serial/DriverSerialSP616E.cpp
+++ b/sources/led-drivers/serial/DriverSerialSP616E.cpp
@@ -1,0 +1,43 @@
+#include <led-drivers/serial/DriverSerialSP616E.h>
+
+// SP616E protocol:
+//   - RGB pixels followed by a 0xFF terminator
+//   - Frame size is dynamic: (_ledRGBCount) + 1 bytes
+//   - No header, no checksum, no length field
+
+static const uint8_t SP616E_TERMINATOR = 0xFF;
+
+DriverSerialSP616E::DriverSerialSP616E(const QJsonObject& deviceConfig)
+	: ProviderSerial(deviceConfig)
+{
+}
+
+bool DriverSerialSP616E::init(QJsonObject deviceConfig)
+{
+	bool isInitOK = false;
+
+	// Initialise sub-class
+	if (ProviderSerial::init(deviceConfig))
+	{
+
+		_ledBuffer.resize(_ledRGBCount + 1, 0x00);
+		_ledBuffer.back() = SP616E_TERMINATOR; // block-end byte
+
+		isInitOK = true;
+	}
+	return isInitOK;
+}
+
+int DriverSerialSP616E::writeFiniteColors(const std::vector<ColorRgb>& ledValues)
+{
+	memcpy(_ledBuffer.data(), ledValues.data(), _ledRGBCount);
+	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
+}
+
+LedDevice* DriverSerialSP616E::construct(const QJsonObject& deviceConfig)
+{
+	return new DriverSerialSP616E(deviceConfig);
+}
+
+bool DriverSerialSP616E::isRegistered = hyperhdr::leds::REGISTER_LED_DEVICE(
+	"sp616e", "leds_group_3_serial", DriverSerialSP616E::construct);

--- a/sources/led-drivers/serial/DriverSerialSP616E.cpp
+++ b/sources/led-drivers/serial/DriverSerialSP616E.cpp
@@ -30,6 +30,14 @@ bool DriverSerialSP616E::init(QJsonObject deviceConfig)
 
 int DriverSerialSP616E::writeFiniteColors(const std::vector<ColorRgb>& ledValues)
 {
+	if (_ledCount != ledValues.size())
+	{
+		Warning(_log, "SP616E led count has changed (old: {:d}, new: {:d}). Rebuilding buffer.", _ledCount, ledValues.size());
+		setLedCount(static_cast<int>(ledValues.size()));
+		_ledBuffer.resize(_ledRGBCount + 1, 0x00);
+		_ledBuffer.back() = SP616E_TERMINATOR;
+	}
+
 	memcpy(_ledBuffer.data(), ledValues.data(), _ledRGBCount);
 	return writeBytes(_ledBuffer.size(), _ledBuffer.data());
 }


### PR DESCRIPTION
**Summary**

Add native serial driver support for the SP616E LED controller. The SP616E uses a
simple protocol: raw RGB pixel data followed by a `0xFF` terminator byte, with no
header, checksum, or length field. Default baud rate is 115200.

This follows the same architecture as existing serial drivers (TPM2, SEDU, etc.)
with the standard `ProviderSerial` base class.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

Fixes: #1557

**Other information:**

### Files Changed (4 files, +85 lines)

| File | Type | Description |
|------|------|-------------|
| `include/led-drivers/serial/DriverSerialSP616E.h` | NEW | Header — class declaration inheriting `ProviderSerial` |
| `sources/led-drivers/serial/DriverSerialSP616E.cpp` | NEW | Implementation — init, writeFiniteColors, auto-registration |
| `sources/led-drivers/schemas/schema-sp616e.json` | NEW | JSON schema — output port, baud rate (115200), delay after connect |
| `sources/led-drivers/LedDeviceSchemas.qrc` | MODIFIED | Register the schema in the Qt resource file |

### SP616E Protocol

| Property | Value |
|----------|-------|
| Header | None |
| Pixel format | Raw RGB (3 bytes per LED) |
| Terminator | `0xFF` |
| Frame size | `(LED count × 3) + 1` bytes |
| Checksum | None |
| Default baud | 115200 |
| Default port | `/dev/ttyACM0` |

### Implementation Notes

- Follows the exact same pattern as `DriverSerialTpm2` and `DriverSerialSedu`
- Uses `_ledRGBCount` for buffer sizing (dynamic, no hardcoded LED limit)
- Buffer is zero-initialized with explicit `0x00` fill
- Terminator is set once in `init()` and preserved across frames
  (only the RGB region is overwritten by `memcpy` in `writeFiniteColors`)
- Auto-registers via `REGISTER_LED_DEVICE("sp616e", "leds_group_3_serial", ...)`
<img width="862" height="513" alt="image" src="https://github.com/user-attachments/assets/3ce11658-a61a-462b-9933-3f2b8ebe0b90" />
