### PR TITLE
Fix RGB splitting across E1.31 universes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix RGB splitting across E1.31 universes (#1585) - v22 🆕
 - Fix smoothing algorithm drift in long-running sessions (#1561) - v22 🆕
 - RGBW with Temporal Dithering - powered by Infinite Color Engine (#1483) - v22beta2 🆕
    - Temporal Dithering: Improved Precision and Adaptive Stabilization (#1490) - v22beta2 🆕

--- a/include/led-drivers/net/DriverNetUdpE131.h
+++ b/include/led-drivers/net/DriverNetUdpE131.h
@@ -38,6 +38,7 @@ private:
 	uint8_t _acn_id[12] = { 0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00 };
 	QString _e131_source_name;
 	QUuid _e131_cid;
+	bool _disableSplitting = false;
 
 	static bool isRegistered;
 };

--- a/sources/led-drivers/net/DriverNetUdpE131.cpp
+++ b/sources/led-drivers/net/DriverNetUdpE131.cpp
@@ -51,7 +51,6 @@ namespace
 	const uint32_t VECTOR_ROOT_E131_DATA = 0x00000004;
 	const uint8_t VECTOR_DMP_SET_PROPERTY = 0x02;
 	const uint32_t VECTOR_E131_DATA_PACKET = 0x00000002;
-	const int DMX_MAX = 512;
 }
 
 DriverNetUdpE131::DriverNetUdpE131(const QJsonObject& deviceConfig)
@@ -71,6 +70,7 @@ bool DriverNetUdpE131::init(QJsonObject deviceConfig)
 	{
 		_e131_universe = deviceConfig["universe"].toInt(1);
 		_e131_source_name = deviceConfig["source-name"].toString("hyperhdr on " + QHostInfo::localHostName());
+		_disableSplitting = deviceConfig["disableSplitting"].toBool(false);
 		QString _json_cid = deviceConfig["cid"].toString("");
 
 		if (_json_cid.isEmpty())
@@ -138,6 +138,7 @@ int DriverNetUdpE131::writeFiniteColors(const std::vector<ColorRgb>& ledValues)
 	int thisChannelCount = 0;
 	int dmxChannelCount = _ledRGBCount;
 	const uint8_t* rawdata = reinterpret_cast<const uint8_t*>(ledValues.data());
+	const int DMX_MAX = (_disableSplitting) ? 510 : 512;
 
 	_e131_seq++;
 

--- a/sources/led-drivers/schemas/schema-e131.json
+++ b/sources/led-drivers/schemas/schema-e131.json
@@ -21,6 +21,13 @@
 			"default": 1,
 			"propertyOrder" : 3
 		},
+		"disableSplitting": {
+			"type": "boolean",
+			"format": "checkbox",
+			"title":"edt_prevent_pixel_data_splitting_across_universes",
+			"default" : false,
+			"propertyOrder" : 4
+		},
 		"cid": {
 			"type": "string",
 			"title":"edt_dev_spec_cid_title",


### PR DESCRIPTION
Add configurable driver option to prevent RGB splitting across E1.31 universes
Fixes #1581 